### PR TITLE
Running builds sequentially

### DIFF
--- a/Sources/Pipeline/Pipeline.swift
+++ b/Sources/Pipeline/Pipeline.swift
@@ -83,19 +83,18 @@ struct Pipeline {
 private extension Pipeline {
     
     func buildProjects(oldSource: ProjectSource, newSource: ProjectSource, scheme: String?) async throws -> (URL, URL) {
-        async let oldBuildResult = try projectBuilder.build(
+        
+        // We don't run them in parallel to not conflict with resolving dependencies concurrently
+        
+        let oldProjectUrl = try await projectBuilder.build(
             source: oldProjectSource,
             scheme: scheme
         )
         
-        async let newBuildResult = try projectBuilder.build(
+        let newProjectUrl = try await projectBuilder.build(
             source: newProjectSource,
             scheme: scheme
         )
-        
-        // Awaiting the result of the async builds
-        let oldProjectUrl = try await oldBuildResult
-        let newProjectUrl = try await newBuildResult
         
         return (oldProjectUrl, newProjectUrl)
     }


### PR DESCRIPTION
## Background
For some reason running builds in parallel started causing issues resolving dependencies
```
failed downloading 'https://github.com/SwiftGen/SwiftGen/releases/download/6.6.2/swiftgen-6.6.2.artifactbundle.zip' which is required by binary target 'swiftgen'
```

## Summary
- Switching to running builds sequentially to make it reliable again


