### PR TITLE
Adding shields.io badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![🧪 Run Tests](https://github.com/Adyen/adyen-swift-public-api-diff/actions/workflows/run-tests.yml/badge.svg)](https://github.com/Adyen/adyen-swift-public-api-diff/actions/workflows/run-tests.yml)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAdyen%2Fadyen-swift-public-api-diff%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Adyen/adyen-swift-public-api-diff)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAdyen%2Fadyen-swift-public-api-diff%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Adyen/adyen-swift-public-api-diff)
 
 ![github-header](https://github.com/user-attachments/assets/08ec7d60-eb0f-4937-b44a-afff02eff72c)
 


### PR DESCRIPTION
## Summary
- Adding shields.io badges to README.md

See: https://github.com/Adyen/adyen-swift-public-api-diff/blob/shields-io-badges/README.md

<img width="552" alt="Screenshot 2024-11-19 at 11 13 41" src="https://github.com/user-attachments/assets/2f7dc34a-f89c-4366-bac5-194e07dda466">
