### PR TITLE
Adding multi line formatting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "5fdd6a5707372450676ad7b5d9fdc0c43fc7717e",
-        "version" : "0.55.0"
+        "revision" : "2d5a2b6bde636c1feae2c852ab9a50f221e98c66",
+        "version" : "0.55.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "7c80ce6f142164b0201871e580b021d1b2c69804",
-        "version" : "0.57.0"
+        "revision" : "f9731bef175c3eea3a0ca960f1be78fcc2bc7853",
+        "version" : "0.57.1"
       }
     }
   ],

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/String+Convenience.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/String+Convenience.swift
@@ -1,0 +1,37 @@
+//
+//  String+Convenience.swift
+//  public-api-diff
+//
+//  Created by Alexander Guretzki on 04/12/2024.
+//
+
+import Foundation
+
+internal extension String {
+    
+    /// Appends a string using a separator
+    ///
+    /// - Parameters:
+    ///   - element: The string to append
+    ///   - separator: The separator to use when appending the string
+    ///   - template: The template to use to build the string (Helpful when the element is optional)
+    ///
+    /// - Important: The string is not added if it's nil or empty \
+    /// If **self** is empty, the separator is ignored and **self** gets the value of the passed string
+    mutating func append(
+        _ element: String?,
+        with separator: String,
+        template: ((String) -> String) = { string in return string }
+    ) {
+        guard let element, !element.isEmpty else { return }
+        
+        let compiledElement = template(element)
+        
+        if self.isEmpty {
+            self = compiledElement
+            return
+        }
+        
+        self = [self, compiledElement].joined(separator: separator)
+    }
+}

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
@@ -76,28 +76,14 @@ extension SwiftInterfaceActor {
 private extension SwiftInterfaceActor {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["actor"]
-
-        components += [{
-            var components = [
-                name,
-                genericParameterDescription
-            ].compactMap { $0 }.joined()
-
-            if let inheritance, !inheritance.isEmpty {
-                components += ": \(inheritance.joined(separator: ", "))"
-            }
-
-            return components
-        }()]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("actor", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
@@ -79,7 +79,8 @@ private extension SwiftInterfaceActor {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("actor", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("actor", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
@@ -76,7 +76,8 @@ private extension SwiftInterfaceAssociatedType {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("associatedtype", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("associatedtype", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
         description.append(initializerValue, with: " ") { "= \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
@@ -73,23 +73,14 @@ extension SwiftInterfaceAssociatedType {
 private extension SwiftInterfaceAssociatedType {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["associatedtype"]
-
-        if let inheritance, !inheritance.isEmpty {
-            components += ["\(name): \(inheritance.joined(separator: ", "))"]
-        } else {
-            components += [name]
-        }
-
-        initializerValue.map { components += ["= \($0)"] }
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("associatedtype", with: " ")
+        description.append(name, with: " ")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(initializerValue, with: " ") { "= \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
@@ -76,28 +76,14 @@ extension SwiftInterfaceClass {
 private extension SwiftInterfaceClass {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["class"]
-
-        components += [{
-            var components = [
-                name,
-                genericParameterDescription
-            ].compactMap { $0 }.joined()
-
-            if let inheritance, !inheritance.isEmpty {
-                components += ": \(inheritance.joined(separator: ", "))"
-            }
-
-            return components
-        }()]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("class", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
@@ -79,7 +79,8 @@ private extension SwiftInterfaceClass {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("class", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("class", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
@@ -74,28 +74,14 @@ extension SwiftInterfaceEnum {
 private extension SwiftInterfaceEnum {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["enum"]
-
-        components += [{
-            var components = [
-                name,
-                genericParameterDescription
-            ].compactMap { $0 }.joined()
-
-            if let inheritance, !inheritance.isEmpty {
-                components += ": \(inheritance.joined(separator: ", "))"
-            }
-
-            return components
-        }()]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("enum", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
@@ -77,7 +77,8 @@ private extension SwiftInterfaceEnum {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("enum", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("enum", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
@@ -96,20 +96,18 @@ extension SwiftInterfaceEnumCase {
 
 private extension SwiftInterfaceEnumCase {
 
+    var parameterDescription: String? {
+        guard let parameters else { return nil }
+        return formattedParameterDescription(for: parameters.map(\.description))
+    }
+    
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["case"]
-
-        if let parameters {
-            components += ["\(name)(\(parameters.map(\.description).joined(separator: ", ")))"]
-        } else {
-            components += [name]
-        }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("case", with: " ")
+        description.append(name, with: " ")
+        description.append(parameterDescription, with: "") { "(\($0))" }
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
@@ -105,7 +105,8 @@ private extension SwiftInterfaceEnumCase {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("case", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("case", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(parameterDescription, with: "") { "(\($0))" }
         return description

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -74,7 +74,8 @@ private extension SwiftInterfaceExtension {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("extension", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("extension", with: modifiers.isEmpty ? "" : " ")
         description.append(extendedType, with: " ")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -71,21 +71,13 @@ extension SwiftInterfaceExtension {
 private extension SwiftInterfaceExtension {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["extension"]
-
-        if let inheritance, !inheritance.isEmpty {
-            components += ["\(extendedType): \(inheritance.joined(separator: ", "))"]
-        } else {
-            components += [extendedType]
-        }
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("extension", with: " ")
+        description.append(extendedType, with: " ")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
@@ -117,26 +117,21 @@ extension SwiftInterfaceFunction {
 
 private extension SwiftInterfaceFunction {
 
+    var parameterDescription: String {
+        formattedParameterDescription(for: parameters.map(\.description))
+    }
+    
     func compileDescription() -> String {
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["func"]
-
-        components += [
-            [
-                name,
-                genericParameterDescription,
-                "(\(parameters.map(\.description).joined(separator: ", ")))"
-            ].compactMap { $0 }.joined()
-        ]
-
-        components += effectSpecifiers
-        components += ["-> \(returnType)"]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("func", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append("(\(parameterDescription))", with: "")
+        description.append(effectSpecifiers.joined(separator: " "), with: " ")
+        description.append(returnType, with: " ") { "-> \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
@@ -125,7 +125,8 @@ private extension SwiftInterfaceFunction {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("func", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("func", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append("(\(parameterDescription))", with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
@@ -115,25 +115,20 @@ extension SwiftInterfaceInitializer {
 
 private extension SwiftInterfaceInitializer {
 
+    var parameterDescription: String {
+        formattedParameterDescription(for: parameters.map(\.description))
+    }
+    
     func compileDescription() -> String {
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-
-        components += [
-            [
-                "init",
-                optionalMark,
-                genericParameterDescription,
-                "(\(parameters.map(\.description).joined(separator: ", ")))"
-            ].compactMap { $0 }.joined()
-        ]
-
-        components += effectSpecifiers
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("init", with: " ")
+        description.append(optionalMark, with: "")
+        description.append(genericParameterDescription, with: "")
+        description.append("(\(parameterDescription))", with: "")
+        description.append(effectSpecifiers.joined(separator: " "), with: " ")
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
@@ -123,7 +123,8 @@ private extension SwiftInterfaceInitializer {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("init", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("init", with: modifiers.isEmpty ? "" : " ")
         description.append(optionalMark, with: "")
         description.append(genericParameterDescription, with: "")
         description.append("(\(parameterDescription))", with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
@@ -77,7 +77,8 @@ private extension SwiftInterfaceProtocol {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("protocol", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("protocol", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(primaryAssociatedTypes.map { "<\($0.joined(separator: ", "))>" }, with: "")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
@@ -74,28 +74,14 @@ extension SwiftInterfaceProtocol {
 private extension SwiftInterfaceProtocol {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["protocol"]
-
-        components += [{
-            var components = [
-                name,
-                primaryAssociatedTypes.map { "<\($0.joined(separator: ", "))>" }
-            ].compactMap { $0 }.joined()
-
-            if let inheritance, !inheritance.isEmpty {
-                components += ": \(inheritance.joined(separator: ", "))"
-            }
-
-            return components
-        }()]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("protocol", with: " ")
+        description.append(name, with: " ")
+        description.append(primaryAssociatedTypes.map { "<\($0.joined(separator: ", "))>" }, with: "")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
@@ -72,30 +72,16 @@ extension SwiftInterfaceStruct {
 }
 
 private extension SwiftInterfaceStruct {
-
+    
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["struct"]
-
-        components += [{
-            var components = [
-                name,
-                genericParameterDescription
-            ].compactMap { $0 }.joined()
-
-            if let inheritance, !inheritance.isEmpty {
-                components += ": \(inheritance.joined(separator: ", "))"
-            }
-
-            return components
-        }()]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("struct", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
@@ -77,7 +77,8 @@ private extension SwiftInterfaceStruct {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("struct", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("struct", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
@@ -113,26 +113,20 @@ extension SwiftInterfaceSubscript {
 
 private extension SwiftInterfaceSubscript {
 
+    var parameterDescription: String {
+        formattedParameterDescription(for: parameters.map(\.description))
+    }
+    
     func compileDescription() -> String {
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-
-        components += [
-            [
-                "subscript",
-                genericParameterDescription,
-                "(\(parameters.map(\.description).joined(separator: ", ")))"
-            ].compactMap { $0 }.joined()
-        ]
-
-        components += ["-> \(returnType)"]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        accessors.map { components += ["{ \($0) }"] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("subscript", with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append("(\(parameterDescription))", with: "")
+        description.append(returnType, with: " ") { "-> \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        description.append(accessors, with: " ") { "{ \($0) }" }
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
@@ -121,7 +121,8 @@ private extension SwiftInterfaceSubscript {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("subscript", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("subscript", with: modifiers.isEmpty ? "" : " ")
         description.append(genericParameterDescription, with: "")
         description.append("(\(parameterDescription))", with: "")
         description.append(returnType, with: " ") { "-> \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
@@ -73,24 +73,14 @@ extension SwiftInterfaceTypeAlias {
 private extension SwiftInterfaceTypeAlias {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += ["typealias"]
-
-        components += [
-            [
-                name,
-                genericParameterDescription
-            ].compactMap { $0 }.joined()
-        ]
-
-        components += ["= \(initializerValue)"]
-
-        genericWhereClauseDescription.map { components += [$0] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append("typealias", with: " ")
+        description.append(name, with: " ")
+        description.append(genericParameterDescription, with: "")
+        description.append(initializerValue, with: " ") { "= \($0)" }
+        description.append(genericWhereClauseDescription, with: " ")
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
@@ -76,7 +76,8 @@ private extension SwiftInterfaceTypeAlias {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append("typealias", with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append("typealias", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
         description.append(initializerValue, with: " ") { "= \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
@@ -79,7 +79,8 @@ private extension SwiftInterfaceVar {
         var description = ""
         description.append(attributes.joined(separator: "\n"), with: "")
         description.append(modifiers.joined(separator: " "), with: "\n")
-        description.append(bindingSpecifier, with: " ")
+        if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
+        description.append(bindingSpecifier, with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(typeAnnotation, with: "") { ": \($0)" }
         description.append(initializerValue, with: " ") { "= \($0)" }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
@@ -76,17 +76,14 @@ extension SwiftInterfaceVar {
 private extension SwiftInterfaceVar {
 
     func compileDescription() -> String {
-
-        var components = [String]()
-
-        components += attributes
-        components += modifiers
-        components += [bindingSpecifier]
-        components += ["\(name): \(typeAnnotation)"]
-
-        initializerValue.map { components += ["= \($0)"] }
-        accessors.map { components += ["{ \($0) }"] }
-
-        return components.joined(separator: " ")
+        var description = ""
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
+        description.append(bindingSpecifier, with: " ")
+        description.append(name, with: " ")
+        description.append(typeAnnotation, with: "") { ": \($0)" }
+        description.append(initializerValue, with: " ") { "= \($0)" }
+        description.append(accessors, with: " ") { "{ \($0) }" }
+        return description
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement+ParameterDescription.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement+ParameterDescription.swift
@@ -1,0 +1,21 @@
+//
+//  SwiftInterfaceElement+Parameters.swift
+//  public-api-diff
+//
+//  Created by Alexander Guretzki on 04/12/2024.
+//
+
+import Foundation
+
+extension SwiftInterfaceElement {
+    func formattedParameterDescription(for parameterDescriptions: [String]) -> String {
+        // We're only doing multiline formatting if we have more than 1 character
+        guard parameterDescriptions.count > 1 else { return parameterDescriptions.joined(separator: ", ") }
+        
+        let spacer = "  "
+        var description = "\n\(spacer)"
+        description.append(parameterDescriptions.joined(separator: ",\n\(spacer)"))
+        description.append("\n")
+        return description
+    }
+}

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -120,11 +120,11 @@ extension SwiftInterfaceElement {
     /// Produces the complete recursive description of the element
     func recursiveDescription(indentation: Int = 0) -> String {
         let spacer = "  "
-        var recursiveDescription = "\(String(repeating: spacer, count: indentation))\(description)"
+        var recursiveDescription = "\(indentedDescription(indentation: indentation))"
         if !self.children.isEmpty {
-            recursiveDescription.append("\n\(String(repeating: spacer, count: indentation)){")
+            recursiveDescription.append(" {")
             for child in self.children {
-                recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))\(child.recursiveDescription(indentation: indentation + 1))")
+                recursiveDescription.append("\n\(child.recursiveDescription(indentation: indentation + 1))")
             }
             recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))}")
         }
@@ -134,5 +134,13 @@ extension SwiftInterfaceElement {
         }
 
         return recursiveDescription
+    }
+    
+    func indentedDescription(indentation: Int) -> String {
+        var components = description.components(separatedBy: .newlines)
+        for (index, component) in components.enumerated() {
+            components[index] = "\(String(repeating: "  ", count: indentation))\(component)"
+        }
+        return components.joined(separator: "\n")
     }
 }

--- a/Sources/Shared/Package/SwiftPackageFileHelperModule/SwiftPackageFileHelper.swift
+++ b/Sources/Shared/Package/SwiftPackageFileHelperModule/SwiftPackageFileHelper.swift
@@ -107,7 +107,7 @@ private extension SwiftPackageFileHelper {
         let errorTag = "error: "
         let warningTag = "warning: "
 
-        var packageDescriptionLines = result.components(separatedBy: newLine)
+        var packageDescriptionLines = result.components(separatedBy: "\n")
         var warnings = [String]()
 
         while let firstLine = packageDescriptionLines.first {
@@ -130,7 +130,7 @@ private extension SwiftPackageFileHelper {
 
             if
                 firstLine.starts(with: "{"),
-                let packageDescriptionData = packageDescriptionLines.joined(separator: newLine).data(using: .utf8) {
+                let packageDescriptionData = packageDescriptionLines.joined(separator: "\n").data(using: .utf8) {
                 return try decodePackageDescription(from: packageDescriptionData, warnings: warnings)
             }
 

--- a/Tests/IntegrationTests/ReferencePackageTests.swift
+++ b/Tests/IntegrationTests/ReferencePackageTests.swift
@@ -64,8 +64,6 @@ class ReferencePackageTests: XCTestCase {
             newVersionName: "new_public",
             warnings: []
         )
-        
-        print(markdownOutput)
 
         let expectedLines = sanitizeOutput(expectedOutput).components(separatedBy: "\n")
         let markdownOutputLines = sanitizeOutput(markdownOutput).components(separatedBy: "\n")
@@ -92,8 +90,6 @@ class ReferencePackageTests: XCTestCase {
             newVersionName: "new_private",
             warnings: []
         )
-        
-        print(markdownOutput)
 
         let expectedLines = sanitizeOutput(expectedOutput).components(separatedBy: "\n")
         let markdownOutputLines = sanitizeOutput(markdownOutput).components(separatedBy: "\n")

--- a/Tests/IntegrationTests/ReferencePackageTests.swift
+++ b/Tests/IntegrationTests/ReferencePackageTests.swift
@@ -64,6 +64,8 @@ class ReferencePackageTests: XCTestCase {
             newVersionName: "new_public",
             warnings: []
         )
+        
+        print(markdownOutput)
 
         let expectedLines = sanitizeOutput(expectedOutput).components(separatedBy: "\n")
         let markdownOutputLines = sanitizeOutput(markdownOutput).components(separatedBy: "\n")
@@ -90,6 +92,8 @@ class ReferencePackageTests: XCTestCase {
             newVersionName: "new_private",
             warnings: []
         )
+        
+        print(markdownOutput)
 
         let expectedLines = sanitizeOutput(expectedOutput).components(separatedBy: "\n")
         let markdownOutputLines = sanitizeOutput(markdownOutput).components(separatedBy: "\n")

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -5,8 +5,7 @@ _Comparing `new_private` to `old_private`_
 ## `ReferencePackage`
 #### ❇️ Added
 ```javascript
-public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable
-{
+public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable {
   case one
   case two
   public init?(rawValue: Swift.String)
@@ -16,16 +15,14 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
 
 ```
 ```javascript
-public protocol ParentProtocol
-{
+public protocol ParentProtocol {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
 
 ```
 ```javascript
-public protocol ParentProtocol<ParentType>
-{
+public protocol ParentProtocol<ParentType> {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
@@ -38,10 +35,12 @@ public protocol SimpleProtocol
 #### 🔀 Changed
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) open class OpenSpiConformingClass: ReferencePackage.CustomProtocol
+@_spi(SystemProgrammingInterface)
+open class OpenSpiConformingClass: ReferencePackage.CustomProtocol
 
 // To
-@_spi(SystemProgrammingInterface) open class OpenSpiConformingClass<T>: ReferencePackage.CustomProtocol where T : Swift.Strideable
+@_spi(SystemProgrammingInterface)
+open class OpenSpiConformingClass<T>: ReferencePackage.CustomProtocol where T : Swift.Strideable
 
 /**
 Changes:
@@ -105,8 +104,7 @@ Changes:
 ### `Array`
 #### ❇️ Added
 ```javascript
-extension Swift.Array
-{
+extension Swift.Array {
   public subscript(safe index: Swift.Int) -> Element? { get }
 }
 
@@ -140,10 +138,12 @@ public var lazyVar: Swift.String { get set }
 #### 🔀 Changed
 ```javascript
 // From
-@_Concurrency.MainActor public func asyncThrowingFunc() async throws -> Swift.Void
+@_Concurrency.MainActor
+public func asyncThrowingFunc() async throws -> Swift.Void
 
 // To
-@_Concurrency.MainActor public func asyncThrowingFunc<Element>(_ element: Element) async throws -> Swift.Void where Element : Swift.Strideable
+@_Concurrency.MainActor
+public func asyncThrowingFunc<Element>(_ element: Element) async throws -> Swift.Void where Element : Swift.Strideable
 
 /**
 Changes:
@@ -203,15 +203,13 @@ case e(ReferencePackage.CustomEnum<T>.NestedStructInExtension)
 
 ```
 ```javascript
-extension ReferencePackage.CustomEnum where T == Swift.String
-{
+extension ReferencePackage.CustomEnum where T == Swift.String {
   public var titleOfCaseWithNamedString: Swift.String? { get }
 }
 
 ```
 ```javascript
-public struct NestedStructInExtension
-{
+public struct NestedStructInExtension {
   public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
 }
@@ -220,10 +218,16 @@ public struct NestedStructInExtension
 #### 🔀 Changed
 ```javascript
 // From
-case caseWithTuple(Swift.String, Swift.Int)
+case caseWithTuple(
+  Swift.String,
+  Swift.Int
+)
 
 // To
-case caseWithTuple(_: Swift.String, bar: Swift.Int)
+case caseWithTuple(
+  _: Swift.String,
+  bar: Swift.Int
+)
 
 /**
 Changes:
@@ -312,10 +316,12 @@ typealias CustomAssociatedType = Swift.Equatable
 ### `CustomStruct`
 #### ❇️ Added
 ```javascript
-@available(macOS, unavailable, message: "Unavailable on macOS") public struct NestedStruct
-{
-  @available(*, deprecated, renamed: "nestedVar") public let nestedLet: Swift.String { get }
-  @available(swift 5.9) public let nestedVar: Swift.String { get }
+@available(macOS, unavailable, message: "Unavailable on macOS")
+public struct NestedStruct {
+  @available(*, deprecated, renamed: "nestedVar")
+  public let nestedLet: Swift.String { get }
+  @available(swift 5.9)
+  public let nestedVar: Swift.String { get }
 }
 
 ```
@@ -338,10 +344,12 @@ public typealias ParentType = Swift.Double
 #### 🔀 Changed
 ```javascript
 // From
-@discardableResult public func function() -> any Swift.Equatable
+@discardableResult
+public func function() -> any Swift.Equatable
 
 // To
-@discardableResult public func function() -> Swift.Int
+@discardableResult
+public func function() -> Swift.Int
 
 /**
 Changes:
@@ -375,24 +383,31 @@ Changes:
 ### `OpenSpiConformingClass`
 #### ❇️ Added
 ```javascript
-@_spi(SystemProgrammingInterface) public typealias AnotherAssociatedType = T
+@_spi(SystemProgrammingInterface)
+public typealias AnotherAssociatedType = T
 
 ```
 ```javascript
-@_spi(SystemProgrammingInterface) public typealias Iterator = [Swift.Double]
+@_spi(SystemProgrammingInterface)
+public typealias Iterator = [Swift.Double]
 
 ```
 ```javascript
-@_spi(SystemProgrammingInterface) public typealias ParentType = Swift.Double
+@_spi(SystemProgrammingInterface)
+public typealias ParentType = Swift.Double
 
 ```
 #### 🔀 Changed
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) @inlinable public func function() -> ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
+@_spi(SystemProgrammingInterface)
+@inlinable
+public func function() -> ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
 
 // To
-@_spi(SystemProgrammingInterface) @inlinable public func function() -> T
+@_spi(SystemProgrammingInterface)
+@inlinable
+public func function() -> T
 
 /**
 Changes:
@@ -401,10 +416,18 @@ Changes:
 ```
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) public init(getSetVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType, getVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType)
+@_spi(SystemProgrammingInterface)
+public init(
+  getSetVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType,
+  getVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
+)
 
 // To
-@_spi(SystemProgrammingInterface) public init(getSetVar: T, getVar: T)
+@_spi(SystemProgrammingInterface)
+public init(
+  getSetVar: T,
+  getVar: T
+)
 
 /**
 Changes:
@@ -416,10 +439,12 @@ Changes:
 ```
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) public typealias CustomAssociatedType = any Swift.Equatable
+@_spi(SystemProgrammingInterface)
+public typealias CustomAssociatedType = any Swift.Equatable
 
 // To
-@_spi(SystemProgrammingInterface) public typealias CustomAssociatedType = T
+@_spi(SystemProgrammingInterface)
+public typealias CustomAssociatedType = T
 
 /**
 Changes:
@@ -428,10 +453,12 @@ Changes:
 ```
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) public var getSetVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
+@_spi(SystemProgrammingInterface)
+public var getSetVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
 
 // To
-@_spi(SystemProgrammingInterface) public var getSetVar: T
+@_spi(SystemProgrammingInterface)
+public var getSetVar: T
 
 /**
 Changes:
@@ -440,10 +467,12 @@ Changes:
 ```
 ```javascript
 // From
-@_spi(SystemProgrammingInterface) public var getVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
+@_spi(SystemProgrammingInterface)
+public var getVar: ReferencePackage.OpenSpiConformingClass.CustomAssociatedType
 
 // To
-@_spi(SystemProgrammingInterface) public var getVar: T
+@_spi(SystemProgrammingInterface)
+public var getVar: T
 
 /**
 Changes:

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -5,8 +5,7 @@ _Comparing `new_public` to `old_public`_
 ## `ReferencePackage`
 #### ❇️ Added
 ```javascript
-public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable
-{
+public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable {
   case one
   case two
   public init?(rawValue: Swift.String)
@@ -16,16 +15,14 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
 
 ```
 ```javascript
-public protocol ParentProtocol
-{
+public protocol ParentProtocol {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
 
 ```
 ```javascript
-public protocol ParentProtocol<ParentType>
-{
+public protocol ParentProtocol<ParentType> {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
@@ -92,8 +89,7 @@ Changes:
 ### `Array`
 #### ❇️ Added
 ```javascript
-extension Swift.Array
-{
+extension Swift.Array {
   public subscript(safe index: Swift.Int) -> Element? { get }
 }
 
@@ -127,10 +123,12 @@ public var lazyVar: Swift.String { get set }
 #### 🔀 Changed
 ```javascript
 // From
-@_Concurrency.MainActor public func asyncThrowingFunc() async throws -> Swift.Void
+@_Concurrency.MainActor
+public func asyncThrowingFunc() async throws -> Swift.Void
 
 // To
-@_Concurrency.MainActor public func asyncThrowingFunc<Element>(_ element: Element) async throws -> Swift.Void where Element : Swift.Strideable
+@_Concurrency.MainActor
+public func asyncThrowingFunc<Element>(_ element: Element) async throws -> Swift.Void where Element : Swift.Strideable
 
 /**
 Changes:
@@ -190,15 +188,13 @@ case e(ReferencePackage.CustomEnum<T>.NestedStructInExtension)
 
 ```
 ```javascript
-extension ReferencePackage.CustomEnum where T == Swift.String
-{
+extension ReferencePackage.CustomEnum where T == Swift.String {
   public var titleOfCaseWithNamedString: Swift.String? { get }
 }
 
 ```
 ```javascript
-public struct NestedStructInExtension
-{
+public struct NestedStructInExtension {
   public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
 }
@@ -207,10 +203,16 @@ public struct NestedStructInExtension
 #### 🔀 Changed
 ```javascript
 // From
-case caseWithTuple(Swift.String, Swift.Int)
+case caseWithTuple(
+  Swift.String,
+  Swift.Int
+)
 
 // To
-case caseWithTuple(_: Swift.String, bar: Swift.Int)
+case caseWithTuple(
+  _: Swift.String,
+  bar: Swift.Int
+)
 
 /**
 Changes:
@@ -299,10 +301,12 @@ typealias CustomAssociatedType = Swift.Equatable
 ### `CustomStruct`
 #### ❇️ Added
 ```javascript
-@available(macOS, unavailable, message: "Unavailable on macOS") public struct NestedStruct
-{
-  @available(*, deprecated, renamed: "nestedVar") public let nestedLet: Swift.String { get }
-  @available(swift 5.9) public let nestedVar: Swift.String { get }
+@available(macOS, unavailable, message: "Unavailable on macOS")
+public struct NestedStruct {
+  @available(*, deprecated, renamed: "nestedVar")
+  public let nestedLet: Swift.String { get }
+  @available(swift 5.9)
+  public let nestedVar: Swift.String { get }
 }
 
 ```
@@ -325,10 +329,12 @@ public typealias ParentType = Swift.Double
 #### 🔀 Changed
 ```javascript
 // From
-@discardableResult public func function() -> any Swift.Equatable
+@discardableResult
+public func function() -> any Swift.Equatable
 
 // To
-@discardableResult public func function() -> Swift.Int
+@discardableResult
+public func function() -> Swift.Int
 
 /**
 Changes:


### PR DESCRIPTION
## Summary
- Puts `attributes` on separate lines
- Multiline formatting of function parameters if more than one

**Fixed issue**:  69
