### PR TITLE
Fixed recursiveDescription formatting

### DIFF
--- a/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -195,9 +195,9 @@ extension CustomEnum: SimpleProtocol {
     }
 }
 
-extension CustomEnum.NestedStructInExtension {
+extension CustomEnum.NestedStructInExtension: CustomStringConvertible {
 
-    var description: String {
+    public var description: String {
         return string
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
@@ -52,7 +52,7 @@ struct SwiftInterfaceChangeConsolidator: SwiftInterfaceChangeConsolidating {
             let listOfChanges = listOfChanges(between: change, and: match)
 
             if listOfChanges.isEmpty {
-                assertionFailure("We should not end up here - investigate how this happened")
+                print("⚠ We should not end up here - investigate how this happened")
                 break
             }
 

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
@@ -83,7 +83,7 @@ private extension SwiftInterfaceActor {
         description.append("actor", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
@@ -79,7 +79,7 @@ private extension SwiftInterfaceAssociatedType {
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("associatedtype", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(initializerValue, with: " ") { "= \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
@@ -83,7 +83,7 @@ private extension SwiftInterfaceClass {
         description.append("class", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
@@ -81,7 +81,7 @@ private extension SwiftInterfaceEnum {
         description.append("enum", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -77,7 +77,7 @@ private extension SwiftInterfaceExtension {
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("extension", with: modifiers.isEmpty ? "" : " ")
         description.append(extendedType, with: " ")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
@@ -81,7 +81,7 @@ private extension SwiftInterfaceProtocol {
         description.append("protocol", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(primaryAssociatedTypes.map { "<\($0.joined(separator: ", "))>" }, with: "")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
@@ -81,7 +81,7 @@ private extension SwiftInterfaceStruct {
         description.append("struct", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")
         description.append(genericParameterDescription, with: "")
-        description.append(inheritance?.joined(separator: ", "), with: "") { ": \($0)" }
+        description.append(inheritance?.sorted().joined(separator: ", "), with: "") { ": \($0)" }
         description.append(genericWhereClauseDescription, with: " ")
         return description
     }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -129,10 +129,6 @@ extension SwiftInterfaceElement {
             recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))}")
         }
 
-        if indentation == 0 {
-            recursiveDescription.append("\n")
-        }
-
         return recursiveDescription
     }
     

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -123,7 +123,7 @@ extension SwiftInterfaceElement {
         var recursiveDescription = "\(indentedDescription(indentation: indentation))"
         if !self.children.isEmpty {
             recursiveDescription.append(" {")
-            for child in self.children {
+            for child in self.children.sorted(by: { $0.description < $1.description }) {
                 recursiveDescription.append("\n\(child.recursiveDescription(indentation: indentation + 1))")
             }
             recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))}")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
@@ -34,9 +34,8 @@ extension SwiftInterfaceParser {
 
         init(moduleName: String, elements: [any SwiftInterfaceElement]) {
             self.moduleName = moduleName
-            self.children = elements
 
-            self.children = Self.mergeExtensions(for: self.children, moduleName: moduleName)
+            self.children = Self.mergeExtensions(for: elements, moduleName: moduleName)
             self.children.forEach { $0.setupParentRelationships(parent: self) }
         }
 

--- a/Tests/IntegrationTests/ReferencePackageTests.swift
+++ b/Tests/IntegrationTests/ReferencePackageTests.swift
@@ -67,7 +67,7 @@ class ReferencePackageTests: XCTestCase {
 
         let expectedLines = sanitizeOutput(expectedOutput).components(separatedBy: "\n")
         let markdownOutputLines = sanitizeOutput(markdownOutput).components(separatedBy: "\n")
-
+        
         for i in 0..<expectedLines.count {
             if expectedLines[i] != markdownOutputLines[i] {
                 XCTAssertEqual(expectedLines[i], markdownOutputLines[i], "Issue in line \(i)")

--- a/Tests/IntegrationTests/ReferencePackageTests.swift
+++ b/Tests/IntegrationTests/ReferencePackageTests.swift
@@ -70,7 +70,7 @@ class ReferencePackageTests: XCTestCase {
 
         for i in 0..<expectedLines.count {
             if expectedLines[i] != markdownOutputLines[i] {
-                XCTAssertEqual(expectedLines[i], markdownOutputLines[i])
+                XCTAssertEqual(expectedLines[i], markdownOutputLines[i], "Issue in line \(i)")
                 return
             }
         }

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -6,7 +6,7 @@ _Comparing `new_private` to `old_private`_
 ## `ReferencePackage`
 #### ❇️ Added
 ```javascript
-public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable {
+public enum RawValueEnum: Swift.Equatable, Swift.Hashable, Swift.RawRepresentable, Swift.String {
   case one
   case two
   public init?(rawValue: Swift.String)
@@ -16,14 +16,14 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
 ```
 ```javascript
 public protocol ParentProtocol {
-  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
+  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
 }
 ```
 ```javascript
 public protocol ParentProtocol<ParentType> {
-  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
+  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
 }
 ```
 ```javascript
@@ -193,8 +193,8 @@ extension ReferencePackage.CustomEnum where T == Swift.String {
 ```
 ```javascript
 public struct NestedStructInExtension {
-  public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
+  public let string: Swift.String { get }
 }
 ```
 #### 🔀 Modified

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -192,9 +192,10 @@ extension ReferencePackage.CustomEnum where T == Swift.String {
 }
 ```
 ```javascript
-public struct NestedStructInExtension {
+public struct NestedStructInExtension: Swift.CustomStringConvertible {
   public init(string: Swift.String = "Hello")
   public let string: Swift.String { get }
+  public var description: Swift.String { get }
 }
 ```
 #### 🔀 Modified

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -13,25 +13,21 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
   public typealias RawValue = Swift.String
   public var rawValue: Swift.String { get }
 }
-
 ```
 ```javascript
 public protocol ParentProtocol {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
-
 ```
 ```javascript
 public protocol ParentProtocol<ParentType> {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
-
 ```
 ```javascript
 public protocol SimpleProtocol
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -108,33 +104,26 @@ Changes:
 extension Swift.Array {
   public subscript(safe index: Swift.Int) -> Element? { get }
 }
-
 ```
 ### `CustomClass`
 #### ❇️ Added
 ```javascript
 final public let a: Swift.Int { get }
-
 ```
 ```javascript
 final public let b: Swift.Int { get }
-
 ```
 ```javascript
 final public let c: Swift.Int { get }
-
 ```
 ```javascript
 final public let d: Swift.Double { get }
-
 ```
 ```javascript
 public subscript(index: Swift.Int) -> T? { get set }
-
 ```
 ```javascript
 public var lazyVar: Swift.String { get set }
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -181,40 +170,32 @@ Changes:
 #### ❇️ Added
 ```javascript
 case a
-
 ```
 ```javascript
 case b
-
 ```
 ```javascript
 case c
-
 ```
 ```javascript
 case caseWithNamedString(title: T)
-
 ```
 ```javascript
 case d
-
 ```
 ```javascript
 case e(ReferencePackage.CustomEnum<T>.NestedStructInExtension)
-
 ```
 ```javascript
 extension ReferencePackage.CustomEnum where T == Swift.String {
   public var titleOfCaseWithNamedString: Swift.String? { get }
 }
-
 ```
 ```javascript
 public struct NestedStructInExtension {
   public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
 }
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -259,19 +240,15 @@ case caseWithString(Swift.String)
 #### ❇️ Added
 ```javascript
 associatedtype AnotherAssociatedType: Swift.Strideable
-
 ```
 ```javascript
 associatedtype AnotherAssociatedType: Swift.Strideable
-
 ```
 ```javascript
 associatedtype CustomAssociatedType: Swift.Equatable
-
 ```
 ```javascript
 associatedtype CustomAssociatedType: Swift.Equatable
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -324,23 +301,18 @@ public struct NestedStruct {
   @available(swift 5.9)
   public let nestedVar: Swift.String { get }
 }
-
 ```
 ```javascript
 public typealias AnotherAssociatedType = Swift.Double
-
 ```
 ```javascript
 public typealias CustomAssociatedType = Swift.Int
-
 ```
 ```javascript
 public typealias Iterator = [ReferencePackage.CustomStruct<T>.AnotherAssociatedType]
-
 ```
 ```javascript
 public typealias ParentType = Swift.Double
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -386,17 +358,14 @@ Changes:
 ```javascript
 @_spi(SystemProgrammingInterface)
 public typealias AnotherAssociatedType = T
-
 ```
 ```javascript
 @_spi(SystemProgrammingInterface)
 public typealias Iterator = [Swift.Double]
-
 ```
 ```javascript
 @_spi(SystemProgrammingInterface)
 public typealias ParentType = Swift.Double
-
 ```
 #### 🔀 Modified
 ```javascript

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -177,9 +177,10 @@ extension ReferencePackage.CustomEnum where T == Swift.String {
 }
 ```
 ```javascript
-public struct NestedStructInExtension {
+public struct NestedStructInExtension: Swift.CustomStringConvertible {
   public init(string: Swift.String = "Hello")
   public let string: Swift.String { get }
+  public var description: Swift.String { get }
 }
 ```
 #### 🔀 Modified

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -13,25 +13,21 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
   public typealias RawValue = Swift.String
   public var rawValue: Swift.String { get }
 }
-
 ```
 ```javascript
 public protocol ParentProtocol {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
-
 ```
 ```javascript
 public protocol ParentProtocol<ParentType> {
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
 }
-
 ```
 ```javascript
 public protocol SimpleProtocol
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -93,33 +89,26 @@ Changes:
 extension Swift.Array {
   public subscript(safe index: Swift.Int) -> Element? { get }
 }
-
 ```
 ### `CustomClass`
 #### ❇️ Added
 ```javascript
 final public let a: Swift.Int { get }
-
 ```
 ```javascript
 final public let b: Swift.Int { get }
-
 ```
 ```javascript
 final public let c: Swift.Int { get }
-
 ```
 ```javascript
 final public let d: Swift.Double { get }
-
 ```
 ```javascript
 public subscript(index: Swift.Int) -> T? { get set }
-
 ```
 ```javascript
 public var lazyVar: Swift.String { get set }
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -166,40 +155,32 @@ Changes:
 #### ❇️ Added
 ```javascript
 case a
-
 ```
 ```javascript
 case b
-
 ```
 ```javascript
 case c
-
 ```
 ```javascript
 case caseWithNamedString(title: T)
-
 ```
 ```javascript
 case d
-
 ```
 ```javascript
 case e(ReferencePackage.CustomEnum<T>.NestedStructInExtension)
-
 ```
 ```javascript
 extension ReferencePackage.CustomEnum where T == Swift.String {
   public var titleOfCaseWithNamedString: Swift.String? { get }
 }
-
 ```
 ```javascript
 public struct NestedStructInExtension {
   public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
 }
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -244,19 +225,15 @@ case caseWithString(Swift.String)
 #### ❇️ Added
 ```javascript
 associatedtype AnotherAssociatedType: Swift.Strideable
-
 ```
 ```javascript
 associatedtype AnotherAssociatedType: Swift.Strideable
-
 ```
 ```javascript
 associatedtype CustomAssociatedType: Swift.Equatable
-
 ```
 ```javascript
 associatedtype CustomAssociatedType: Swift.Equatable
-
 ```
 #### 🔀 Modified
 ```javascript
@@ -309,23 +286,18 @@ public struct NestedStruct {
   @available(swift 5.9)
   public let nestedVar: Swift.String { get }
 }
-
 ```
 ```javascript
 public typealias AnotherAssociatedType = Swift.Double
-
 ```
 ```javascript
 public typealias CustomAssociatedType = Swift.Int
-
 ```
 ```javascript
 public typealias Iterator = [ReferencePackage.CustomStruct<T>.AnotherAssociatedType]
-
 ```
 ```javascript
 public typealias ParentType = Swift.Double
-
 ```
 #### 🔀 Modified
 ```javascript

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -6,7 +6,7 @@ _Comparing `new_public` to `old_public`_
 ## `ReferencePackage`
 #### ❇️ Added
 ```javascript
-public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.RawRepresentable {
+public enum RawValueEnum: Swift.Equatable, Swift.Hashable, Swift.RawRepresentable, Swift.String {
   case one
   case two
   public init?(rawValue: Swift.String)
@@ -16,14 +16,14 @@ public enum RawValueEnum: Swift.String, Swift.Equatable, Swift.Hashable, Swift.R
 ```
 ```javascript
 public protocol ParentProtocol {
-  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
+  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
 }
 ```
 ```javascript
 public protocol ParentProtocol<ParentType> {
-  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
   associatedtype Iterator: Swift.Collection
+  associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
 }
 ```
 ```javascript
@@ -178,8 +178,8 @@ extension ReferencePackage.CustomEnum where T == Swift.String {
 ```
 ```javascript
 public struct NestedStructInExtension {
-  public let string: Swift.String { get }
   public init(string: Swift.String = "Hello")
+  public let string: Swift.String { get }
 }
 ```
 #### 🔀 Modified


### PR DESCRIPTION
## Summary
- Removed trailing newline in recursiveDescription
- Replaced assertionFailure with print to not cause crashes when running in debug mode (which is currently the easiest way of integrating the tool)
