### PR TITLE
Release 0.7.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: actions/checkout@v4
       with:
         repository: "Adyen/adyen-swift-public-api-diff"
-        ref: "0.6.0"
+        ref: "0.7.0"
     - name: "Run Diff"
       run: |
         NEW=${{ inputs.new }}


### PR DESCRIPTION
## Summary
- Switching from assertionFailure to print for debug warnings (Currently the CI action runs on the debug build and thus would crash otherwise in a scenario where it's not expected)
- Polished output