### PR TITLE
Adding `OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface`

### DIFF
--- a/Sources/PublicModules/PADProjectBuilder/SwiftInterfaceProducer/XcodeTools.swift
+++ b/Sources/PublicModules/PADProjectBuilder/SwiftInterfaceProducer/XcodeTools.swift
@@ -57,7 +57,8 @@ struct XcodeTools {
             "cd \(projectDirectoryPath);",
             "xcodebuild clean build -scheme \"\(scheme)\"",
             "-derivedDataPath \(Constants.derivedDataPath)",
-            "BUILD_LIBRARY_FOR_DISTRIBUTION=YES"
+            "BUILD_LIBRARY_FOR_DISTRIBUTION=YES",
+            "OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface"
         ]
         
         switch platform {

--- a/Tests/UnitTests/XcodeToolsTests.swift
+++ b/Tests/UnitTests/XcodeToolsTests.swift
@@ -61,7 +61,8 @@ private extension XcodeToolsTests {
         var commandComponents = [
             "cd \(projectDirectoryPath);",
             "xcodebuild clean build -scheme \"\(scheme)\"",
-            "-derivedDataPath .build BUILD_LIBRARY_FOR_DISTRIBUTION=YES"
+            "-derivedDataPath .build BUILD_LIBRARY_FOR_DISTRIBUTION=YES",
+            "OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface"
         ]
         
         switch platform {


### PR DESCRIPTION
## Summary
- Removes the verification of emitted module interfaces (.swiftinterface files) - this solves some build failures that were caused by modules not being able to build with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`

## Also see
- Inspiration: https://github.com/swiftlang/swift-markdown/issues/195
- Partially fixes: https://github.com/Adyen/adyen-swift-public-api-diff/issues/84
