### PR TITLE
Highlighting if empty targets are provided

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        xcodebuild test -scheme public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme public-api-diff -testPlan public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4'
+        xcode-version: '16.0'
         
     - name: 🛠️ Run All Tests
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,5 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        cd Tests
-        swift test --enable-swift-testing --enable-xctest | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme public-api-diff-Package -testPlan public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.1'
         
     - name: 🛠️ Run All Tests
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        swift test | exit ${PIPESTATUS[0]}
+        swift test --enable-swift-testing --enable-xctest | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        xcodebuild test -scheme public-api-diff-Package -testPlan public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme public-api-diff-Package -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,5 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
+        cd Tests
         swift test --enable-swift-testing --enable-xctest | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        xcodebuild test -scheme public-api-diff -testPlan public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        swift test | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        xcodebuild test -scheme public-api-diff -destination "platform=iOS,name=Any iOS Device" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme public-api-diff -destination "platform=macOS" -skipPackagePluginValidation | xcpretty --utf --color && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         
     - name: 🛠️ Run All Tests
       run: |
-        swift test | xcpretty --utf --color && exit ${PIPESTATUS[0]}
+        swift test | exit ${PIPESTATUS[0]}

--- a/Sources/PublicModules/PADOutputGenerator/MarkdownOutputGenerator.swift
+++ b/Sources/PublicModules/PADOutputGenerator/MarkdownOutputGenerator.swift
@@ -25,7 +25,7 @@ public struct MarkdownOutputGenerator: OutputGenerating {
         let changes = Self.changeLines(changesPerModule: changesPerTarget)
 
         var lines = [
-            Self.title(changesPerTarget: changesPerTarget)
+            Self.title(changesPerTarget: changesPerTarget, allTargets: allTargets)
         ]
 
         if let oldVersionName, let newVersionName {
@@ -46,7 +46,7 @@ public struct MarkdownOutputGenerator: OutputGenerating {
             lines += changes + [separator]
         }
 
-        if let allTargets {
+        if let allTargets, !allTargets.isEmpty {
             lines += [
                 Self.analyzedModulesInfo(allTargets: allTargets)
             ]
@@ -60,7 +60,15 @@ public struct MarkdownOutputGenerator: OutputGenerating {
 
 private extension MarkdownOutputGenerator {
 
-    static func title(changesPerTarget: [String: [Change]]) -> String {
+    static func title(
+        changesPerTarget: [String: [Change]],
+        allTargets: [String]?
+    ) -> String {
+        
+        if let allTargets, allTargets.isEmpty {
+            // We got targets but the list is empty -> Show an error
+            return "# ‼️ No analyzable targets detected"
+        }
 
         if changesPerTarget.keys.isEmpty {
             return "# ✅ No changes detected"

--- a/Sources/PublicModules/PADOutputGenerator/OutputGenerating.swift
+++ b/Sources/PublicModules/PADOutputGenerator/OutputGenerating.swift
@@ -15,7 +15,7 @@ public protocol OutputGenerating<OutputType> {
     /// Generates an output from input parameters
     /// - Parameters:
     ///   - changesPerTarget: A list of changes per target/module
-    ///   - allTargets: A list of all targets/modules that were analysed in previous steps
+    ///   - allTargets: A list of all targets/modules that were analysed in previous steps - if targets are provided but the list is empty it is treated like a failure
     ///   - oldVersionName: The name of the old/reference version
     ///   - newVersionName: The name of the new/updated version
     ///   - warnings: A list of warnings produced in previous steps

--- a/Tests/UnitTests/OutputGeneratorTests.swift
+++ b/Tests/UnitTests/OutputGeneratorTests.swift
@@ -5,11 +5,12 @@
 //
 
 @testable import PADOutputGenerator
-import XCTest
+import Testing
 
-class OutputGeneratorTests: XCTestCase {
+class OutputGeneratorTests {
 
-    func test_noChanges_singleModule() {
+    @Test
+    func noChanges_singleModule() {
 
         let expectedOutput = """
         # ✅ No changes detected
@@ -27,10 +28,12 @@ class OutputGeneratorTests: XCTestCase {
             newVersionName: "new_source",
             warnings: []
         )
-        XCTAssertEqual(output, expectedOutput)
+        
+        #expect(output == expectedOutput)
     }
 
-    func test_oneChange_singleModule() {
+    @Test
+    func oneChange_singleModule() {
 
         let expectedOutput = """
         # 👀 1 public change detected
@@ -57,10 +60,12 @@ class OutputGeneratorTests: XCTestCase {
             newVersionName: "new_source",
             warnings: []
         )
-        XCTAssertEqual(output, expectedOutput)
+        
+        #expect(output == expectedOutput)
     }
 
-    func test_multipleChanges_multipleModules() {
+    @Test
+    func multipleChanges_multipleModules() {
 
         let expectedOutput = """
         # ⚠️ 4 public changes detected ⚠️
@@ -109,6 +114,55 @@ class OutputGeneratorTests: XCTestCase {
             newVersionName: "new_source",
             warnings: []
         )
-        XCTAssertEqual(output, expectedOutput)
+        
+        #expect(output == expectedOutput)
+    }
+    
+    struct AllTargetsExpectation {
+        let allTargets: [String]?
+        let expectedTitle: String
+        let expectedTargetSection: String
+    }
+    
+    @Test(
+        "allTargets should change the output as expected",
+        arguments: [
+            AllTargetsExpectation(
+                allTargets: [],
+                expectedTitle: "‼️ No analyzable targets detected",
+                expectedTargetSection: ""
+            ),
+            AllTargetsExpectation(
+                allTargets: nil,
+                expectedTitle: "✅ No changes detected",
+                expectedTargetSection: ""
+            ),
+            AllTargetsExpectation(
+                allTargets: ["SomeTarget"],
+                expectedTitle: "✅ No changes detected",
+                expectedTargetSection: "\n**Analyzed targets:** SomeTarget"
+            )
+        ]
+    )
+    func allTargets_shouldChangeOutputAsExpected(argument: AllTargetsExpectation) {
+        
+        let expectedOutput = """
+        # \(argument.expectedTitle)
+        _Comparing `new_source` to `old_repository @ old_branch`_
+
+        ---\(argument.expectedTargetSection)
+        """
+        
+        let outputGenerator = MarkdownOutputGenerator()
+        
+        let output = outputGenerator.generate(
+            from: [:],
+            allTargets: argument.allTargets,
+            oldVersionName: "old_repository @ old_branch",
+            newVersionName: "new_source",
+            warnings: []
+        )
+        
+        #expect(output == expectedOutput)
     }
 }

--- a/Tests/UnitTests/OutputGeneratorTests.swift
+++ b/Tests/UnitTests/OutputGeneratorTests.swift
@@ -5,12 +5,11 @@
 //
 
 @testable import PADOutputGenerator
-import Testing
+import XCTest
 
-class OutputGeneratorTests {
+class OutputGeneratorTests: XCTestCase {
 
-    @Test
-    func noChanges_singleModule() {
+    func test_noChanges_singleModule() {
 
         let expectedOutput = """
         # ✅ No changes detected
@@ -29,11 +28,10 @@ class OutputGeneratorTests {
             warnings: []
         )
         
-        #expect(output == expectedOutput)
+        XCTAssertEqual(output, expectedOutput)
     }
 
-    @Test
-    func oneChange_singleModule() {
+    func test_oneChange_singleModule() {
 
         let expectedOutput = """
         # 👀 1 public change detected
@@ -61,10 +59,9 @@ class OutputGeneratorTests {
             warnings: []
         )
         
-        #expect(output == expectedOutput)
+        XCTAssertEqual(output, expectedOutput)
     }
 
-    @Test
     func multipleChanges_multipleModules() {
 
         let expectedOutput = """
@@ -115,7 +112,7 @@ class OutputGeneratorTests {
             warnings: []
         )
         
-        #expect(output == expectedOutput)
+        XCTAssertEqual(output, expectedOutput)
     }
     
     struct AllTargetsExpectation {
@@ -123,28 +120,33 @@ class OutputGeneratorTests {
         let expectedTitle: String
         let expectedTargetSection: String
     }
-    
-    @Test(
-        "allTargets should change the output as expected",
-        arguments: [
-            AllTargetsExpectation(
+
+    func test_allTargets_shouldChangeOutputAsExpected() {
+        
+        let testExpectations: [AllTargetsExpectation] = [
+            .init(
                 allTargets: [],
                 expectedTitle: "‼️ No analyzable targets detected",
                 expectedTargetSection: ""
             ),
-            AllTargetsExpectation(
+            .init(
                 allTargets: nil,
                 expectedTitle: "✅ No changes detected",
                 expectedTargetSection: ""
             ),
-            AllTargetsExpectation(
+            .init(
                 allTargets: ["SomeTarget"],
                 expectedTitle: "✅ No changes detected",
                 expectedTargetSection: "\n**Analyzed targets:** SomeTarget"
             )
         ]
-    )
-    func allTargets_shouldChangeOutputAsExpected(argument: AllTargetsExpectation) {
+        
+        testExpectations.forEach { argument in
+            allTargets_shouldChangeOutputAsExpected(argument: argument)
+        }
+    }
+    
+    private func allTargets_shouldChangeOutputAsExpected(argument: AllTargetsExpectation) {
         
         let expectedOutput = """
         # \(argument.expectedTitle)
@@ -163,6 +165,6 @@ class OutputGeneratorTests {
             warnings: []
         )
         
-        #expect(output == expectedOutput)
+        XCTAssertEqual(output, expectedOutput)
     }
 }

--- a/Tests/public-api-diff.xctestplan
+++ b/Tests/public-api-diff.xctestplan
@@ -45,6 +45,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "IntegrationTests",
@@ -52,6 +53,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
         "identifier" : "UnitTests",


### PR DESCRIPTION
## Summary
- Highlights if no analyzable targets could be found / were passed to the OutputGenerator

## Changes
- If the OutputGenerator gets called with an empty (but non-nil) list of targets it now shows a different title, highlighting some misconfiguration.

---

<img width="479" alt="Screenshot 2025-02-27 at 13 42 29" src="https://github.com/user-attachments/assets/8af08cd3-2e8b-4824-8724-7ec1bee4b0ad" />