### PR TITLE
Deduplicating default implementations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
-        "version" : "0.58.2"
+        "revision" : "a60b5704f335fc18aa3aea3564c74774a338425f",
+        "version" : "0.59.0"
       }
     }
   ],

--- a/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -38,6 +38,16 @@ public protocol CustomProtocol<CustomAssociatedType, AnotherAssociatedType>: Par
     func function() -> CustomAssociatedType
 }
 
+public protocol ProtocolWithDefaultImplementation {
+    func function() -> String
+}
+
+extension ProtocolWithDefaultImplementation {
+    public func function() -> String {
+        fatalError()
+    }
+}
+
 public struct CustomStruct<T: Strideable>: CustomProtocol {
     public typealias CustomAssociatedType = Int
     public typealias AnotherAssociatedType = Double

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
@@ -36,7 +36,9 @@ class SwiftInterfaceActor: SwiftInterfaceExtendableElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     var typeName: String { name }
 
@@ -75,10 +77,14 @@ extension SwiftInterfaceActor {
 
 private extension SwiftInterfaceActor {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("actor", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Actor.swift
@@ -79,12 +79,12 @@ private extension SwiftInterfaceActor {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("actor", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
@@ -76,12 +76,12 @@ private extension SwiftInterfaceAssociatedType {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("associatedtype", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+AssociatedType.swift
@@ -37,7 +37,9 @@ class SwiftInterfaceAssociatedType: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     init(
         attributes: [String],
@@ -72,10 +74,14 @@ extension SwiftInterfaceAssociatedType {
 
 private extension SwiftInterfaceAssociatedType {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("associatedtype", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
@@ -79,12 +79,12 @@ private extension SwiftInterfaceClass {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("class", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Class.swift
@@ -36,7 +36,9 @@ class SwiftInterfaceClass: SwiftInterfaceExtendableElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     var typeName: String { name }
 
@@ -75,10 +77,14 @@ extension SwiftInterfaceClass {
 
 private extension SwiftInterfaceClass {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("class", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
@@ -34,7 +34,9 @@ class SwiftInterfaceEnum: SwiftInterfaceExtendableElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     var typeName: String { name }
 
@@ -73,10 +75,14 @@ extension SwiftInterfaceEnum {
 
 private extension SwiftInterfaceEnum {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("enum", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Enum.swift
@@ -77,12 +77,12 @@ private extension SwiftInterfaceEnum {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("enum", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
@@ -64,7 +64,9 @@ class SwiftInterfaceEnumCase: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     init(
         attributes: [String],
@@ -101,10 +103,14 @@ private extension SwiftInterfaceEnumCase {
         return formattedParameterDescription(for: parameters.map(\.description))
     }
     
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("case", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+EnumCase.swift
@@ -105,12 +105,12 @@ private extension SwiftInterfaceEnumCase {
     
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("case", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -34,8 +34,8 @@ class SwiftInterfaceExtension: SwiftInterfaceElement {
 
     var consolidatableName: String { extendedType }
 
-    var description: String {
-        compileDescription()
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
     }
 
     init(
@@ -70,10 +70,14 @@ extension SwiftInterfaceExtension {
 
 private extension SwiftInterfaceExtension {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("extension", with: modifiers.isEmpty ? "" : " ")
         description.append(extendedType, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -72,12 +72,12 @@ private extension SwiftInterfaceExtension {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("extension", with: modifiers.isEmpty ? "" : " ")
         description.append(extendedType, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
@@ -130,12 +130,12 @@ private extension SwiftInterfaceFunction {
     
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("func", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Function.swift
@@ -81,7 +81,9 @@ class SwiftInterfaceFunction: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     init(
         attributes: [String],
@@ -126,10 +128,14 @@ private extension SwiftInterfaceFunction {
         formattedParameterDescription(for: parameters.map(\.description))
     }
     
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("func", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
@@ -87,12 +87,12 @@ private extension SwiftInterfaceInitializer {
     
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("init", with: modifiers.isEmpty ? "" : " ")
         description.append(optionalMark, with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Initializer.swift
@@ -40,8 +40,8 @@ class SwiftInterfaceInitializer: SwiftInterfaceElement {
 
     var consolidatableName: String { "init" }
 
-    var description: String {
-        compileDescription()
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
     }
 
     init(
@@ -85,10 +85,14 @@ private extension SwiftInterfaceInitializer {
         formattedParameterDescription(for: parameters.map(\.description))
     }
     
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("init", with: modifiers.isEmpty ? "" : " ")
         description.append(optionalMark, with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
@@ -77,12 +77,12 @@ private extension SwiftInterfaceProtocol {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("protocol", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Protocol.swift
@@ -34,7 +34,9 @@ class SwiftInterfaceProtocol: SwiftInterfaceExtendableElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     var typeName: String { name }
 
@@ -73,10 +75,14 @@ extension SwiftInterfaceProtocol {
 
 private extension SwiftInterfaceProtocol {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("protocol", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
@@ -77,12 +77,12 @@ private extension SwiftInterfaceStruct {
     
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("struct", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Struct.swift
@@ -34,7 +34,9 @@ class SwiftInterfaceStruct: SwiftInterfaceExtendableElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     var typeName: String { name }
 
@@ -73,10 +75,14 @@ extension SwiftInterfaceStruct {
 
 private extension SwiftInterfaceStruct {
     
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("struct", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
@@ -74,7 +74,9 @@ class SwiftInterfaceSubscript: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String { compileDescription() }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
+    }
 
     init(
         attributes: [String],
@@ -117,10 +119,14 @@ private extension SwiftInterfaceSubscript {
         formattedParameterDescription(for: parameters.map(\.description))
     }
     
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("subscript", with: modifiers.isEmpty ? "" : " ")
         description.append(genericParameterDescription, with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Subscript.swift
@@ -121,12 +121,12 @@ private extension SwiftInterfaceSubscript {
     
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("subscript", with: modifiers.isEmpty ? "" : " ")
         description.append(genericParameterDescription, with: "")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
@@ -35,8 +35,8 @@ class SwiftInterfaceTypeAlias: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String {
-        compileDescription()
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
     }
 
     init(
@@ -72,10 +72,14 @@ extension SwiftInterfaceTypeAlias {
 
 private extension SwiftInterfaceTypeAlias {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("typealias", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+TypeAlias.swift
@@ -74,12 +74,12 @@ private extension SwiftInterfaceTypeAlias {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append("typealias", with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
@@ -35,8 +35,8 @@ class SwiftInterfaceVar: SwiftInterfaceElement {
 
     var consolidatableName: String { name }
 
-    var description: String {
-        compileDescription()
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        compileDescription(incl: tokens)
     }
 
     init(
@@ -75,10 +75,14 @@ extension SwiftInterfaceVar {
 
 private extension SwiftInterfaceVar {
 
-    func compileDescription() -> String {
+    func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        description.append(attributes.joined(separator: "\n"), with: "")
-        description.append(modifiers.joined(separator: " "), with: "\n")
+        if tokens.contains(.attributes) {
+            description.append(attributes.joined(separator: "\n"), with: "")
+        }
+        if tokens.contains(.modifiers) {
+            description.append(modifiers.joined(separator: " "), with: "\n")
+        }
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append(bindingSpecifier, with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Var.swift
@@ -77,12 +77,12 @@ private extension SwiftInterfaceVar {
 
     func compileDescription(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
         var description = ""
-        if tokens.contains(.attributes) {
-            description.append(attributes.joined(separator: "\n"), with: "")
-        }
-        if tokens.contains(.modifiers) {
-            description.append(modifiers.joined(separator: " "), with: "\n")
-        }
+        var modifiers = modifiers
+        if !tokens.contains(.modifiers) { modifiers = [] }
+        var attributes = attributes
+        if !tokens.contains(.attributes) { attributes = [] }
+        description.append(attributes.joined(separator: "\n"), with: "")
+        description.append(modifiers.joined(separator: " "), with: "\n")
         if modifiers.isEmpty && !attributes.isEmpty { description.append("\n") }
         description.append(bindingSpecifier, with: modifiers.isEmpty ? "" : " ")
         description.append(name, with: " ")

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -19,13 +19,19 @@ protocol SwiftInterfaceExtendableElement: SwiftInterfaceElement {
     var children: [any SwiftInterfaceElement] { get set }
 }
 
-protocol SwiftInterfaceElement: CustomStringConvertible, AnyObject {
+enum SwiftInterfaceElementDescriptionToken: CaseIterable {
+    case attributes
+    case modifiers
+    // Add more tokens when needed
+}
 
+protocol SwiftInterfaceElement: CustomStringConvertible, AnyObject {
+    
     /// The name of the element used to construct the parent path for its children
     var pathComponentName: String { get }
 
     /// The full description of the element (without children)
-    var description: String { get }
+    func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String
 
     /// The cildren of the element (e.g. properties/functions of a struct/class/...)
     var children: [any SwiftInterfaceElement] { get }
@@ -46,6 +52,18 @@ protocol SwiftInterfaceElement: CustomStringConvertible, AnyObject {
 
     /// Produces a list of differences between one and another element
     func differences<T: SwiftInterfaceElement>(to otherElement: T) -> [String]
+}
+
+extension SwiftInterfaceElement {
+    
+    var description: String {
+        description(incl: Set(SwiftInterfaceElementDescriptionToken.allCases))
+    }
+    
+    func description(excl: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        let includedTokens = Set(SwiftInterfaceElementDescriptionToken.allCases).subtracting(excl)
+        return description(incl: includedTokens)
+    }
 }
 
 extension SwiftInterfaceElement {
@@ -120,13 +138,16 @@ extension SwiftInterfaceElement {
 extension SwiftInterfaceElement {
 
     /// Produces the complete recursive description of the element
-    func recursiveDescription(indentation: Int = 0) -> String {
+    func recursiveDescription(
+        indentation: Int = 0,
+        incl tokens: Set<SwiftInterfaceElementDescriptionToken> = Set(SwiftInterfaceElementDescriptionToken.allCases)
+    ) -> String {
         let spacer = "  "
         var recursiveDescription = "\(indentedDescription(indentation: indentation))"
         if !self.children.isEmpty {
             recursiveDescription.append(" {")
-            for child in self.children.sorted(by: { $0.description < $1.description }) {
-                recursiveDescription.append("\n\(child.recursiveDescription(indentation: indentation + 1))")
+            for child in self.children.sorted(by: { $0.description(incl: tokens) < $1.description(incl: tokens) }) {
+                recursiveDescription.append("\n\(child.recursiveDescription(indentation: indentation + 1, incl: tokens))")
             }
             recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))}")
         }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -143,7 +143,7 @@ extension SwiftInterfaceElement {
         incl tokens: Set<SwiftInterfaceElementDescriptionToken> = Set(SwiftInterfaceElementDescriptionToken.allCases)
     ) -> String {
         let spacer = "  "
-        var recursiveDescription = "\(indentedDescription(indentation: indentation))"
+        var recursiveDescription = "\(indentedDescription(indentation: indentation, incl: tokens))"
         if !self.children.isEmpty {
             recursiveDescription.append(" {")
             for child in self.children.sorted(by: { $0.description(incl: tokens) < $1.description(incl: tokens) }) {
@@ -155,8 +155,8 @@ extension SwiftInterfaceElement {
         return recursiveDescription
     }
     
-    func indentedDescription(indentation: Int) -> String {
-        var components = description.components(separatedBy: .newlines)
+    func indentedDescription(indentation: Int, incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
+        var components = description(incl: tokens).components(separatedBy: .newlines)
         for (index, component) in components.enumerated() {
             components[index] = "\(String(repeating: "  ", count: indentation))\(component)"
         }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
@@ -18,10 +18,10 @@ extension SwiftInterfaceParser {
         var consolidatableName: String { "" }
 
         /// Produces the complete recursive description of the interface
-        var description: String {
+        func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
             var description = ""
             children.forEach { child in
-                description.append(child.recursiveDescription())
+                description.append(child.recursiveDescription(incl: tokens))
                 description.append("\n")
             }
             return description
@@ -141,7 +141,18 @@ private extension SwiftInterfaceParser.Root {
         // We found the extended type
         if extendedElementPrefix == extensionElement.extendedType {
             extendedElement.inheritance = (extendedElement.inheritance ?? []) + (extensionElement.inheritance ?? [])
-            extendedElement.children += extensionElement.children
+            
+            print(extendedElement.children)
+            print(extensionElement.children)
+            
+            extensionElement.children.forEach { child in
+                // Filtering out default implementations with custom modifiers (public/package/...)
+                if extendedElement.children.contains(where: { $0.description(excl: [.modifiers]) == child.description(excl: [.modifiers]) }) {
+                    return
+                }
+                extendedElement.children += [child]
+            }
+            
             return true
         }
 

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
@@ -19,12 +19,11 @@ extension SwiftInterfaceParser {
 
         /// Produces the complete recursive description of the interface
         func description(incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
-            var description = ""
+            var descriptionElements: [String] = []
             children.forEach { child in
-                description.append(child.recursiveDescription(incl: tokens))
-                description.append("\n")
+                descriptionElements.append(child.recursiveDescription(incl: tokens))
             }
-            return description
+            return descriptionElements.joined(separator: "\n")
         }
 
         var pathComponentName: String { moduleName }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceParser+Root.swift
@@ -142,12 +142,11 @@ private extension SwiftInterfaceParser.Root {
         if extendedElementPrefix == extensionElement.extendedType {
             extendedElement.inheritance = (extendedElement.inheritance ?? []) + (extensionElement.inheritance ?? [])
             
-            print(extendedElement.children)
-            print(extensionElement.children)
-            
             extensionElement.children.forEach { child in
                 // Filtering out default implementations with custom modifiers (public/package/...)
-                if extendedElement.children.contains(where: { $0.description(excl: [.modifiers]) == child.description(excl: [.modifiers]) }) {
+                if extendedElement.children.contains(where: {
+                    $0.description(excl: [.modifiers]) == child.description(excl: [.modifiers])
+                }) {
                     return
                 }
                 extendedElement.children += [child]

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -1,6 +1,6 @@
-# ⚠️ 56 public changes detected ⚠️
+# ⚠️ 57 public changes detected ⚠️
 _Comparing `new_private` to `old_private`_
-<table><tr><td>❇️</td><td><b>32 Additions</b></td></tr><tr><td>🔀</td><td><b>22 Modifications</b></td></tr><tr><td>❌</td><td><b>2 Removals</b></td></tr></table>
+<table><tr><td>❇️</td><td><b>33 Additions</b></td></tr><tr><td>🔀</td><td><b>22 Modifications</b></td></tr><tr><td>❌</td><td><b>2 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -30,6 +30,11 @@ public protocol ParentProtocol {
 public protocol ParentProtocol<ParentType> {
   associatedtype Iterator: Swift.Collection
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
+}
+```
+```javascript
+public protocol ProtocolWithDefaultImplementation {
+  func function() -> Swift.String
 }
 ```
 ```javascript

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -1,6 +1,6 @@
-# ⚠️ 47 public changes detected ⚠️
+# ⚠️ 48 public changes detected ⚠️
 _Comparing `new_public` to `old_public`_
-<table><tr><td>❇️</td><td><b>29 Additions</b></td></tr><tr><td>🔀</td><td><b>16 Modifications</b></td></tr><tr><td>❌</td><td><b>2 Removals</b></td></tr></table>
+<table><tr><td>❇️</td><td><b>30 Additions</b></td></tr><tr><td>🔀</td><td><b>16 Modifications</b></td></tr><tr><td>❌</td><td><b>2 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -30,6 +30,11 @@ public protocol ParentProtocol {
 public protocol ParentProtocol<ParentType> {
   associatedtype Iterator: Swift.Collection
   associatedtype ParentType: Swift.Equatable where Self.ParentType == Self.Iterator.Element
+}
+```
+```javascript
+public protocol ProtocolWithDefaultImplementation {
+  func function() -> Swift.String
 }
 ```
 ```javascript

--- a/Tests/UnitTests/SwiftInterfaceElementDescriptionTests.swift
+++ b/Tests/UnitTests/SwiftInterfaceElementDescriptionTests.swift
@@ -1,0 +1,118 @@
+//
+//  SwiftInterfaceElementDescriptionTests.swift
+//  public-api-diff
+//
+//  Created by Alexander Guretzki on 10/04/2025.
+//
+
+@testable import PADCore
+@testable import PADPackageFileAnalyzer
+@testable import PADSwiftInterfaceDiff
+
+import XCTest
+
+class SwiftInterfaceElementDescriptionTests: XCTestCase {
+    
+    func testRoot() {
+        let root = SwiftInterfaceParser.Root(
+            moduleName: "ModuleName",
+            elements: [
+                SwiftInterfaceClass(
+                    attributes: ["attribute1", "attribute2"],
+                    modifiers: ["modifier1", "modifier2"],
+                    name: "ClassName1",
+                    genericParameterDescription: "<GenericParameterDescription>",
+                    inheritance: ["Inheritance1", "Inheritance2"],
+                    genericWhereClauseDescription: "GenericWhereClause",
+                    children: []
+                ),
+                SwiftInterfaceClass(
+                    attributes: ["attribute1", "attribute2"],
+                    modifiers: ["modifier1", "modifier2"],
+                    name: "ClassName2",
+                    genericParameterDescription: "<GenericParameterDescription>",
+                    inheritance: ["Inheritance1", "Inheritance2"],
+                    genericWhereClauseDescription: "GenericWhereClause",
+                    children: []
+                )
+            ]
+        )
+        
+        XCTAssertEqual(root.description, """
+attribute1
+attribute2
+modifier1 modifier2 class ClassName1<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+attribute1
+attribute2
+modifier1 modifier2 class ClassName2<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(root.description(excl:  [.attributes]), """
+modifier1 modifier2 class ClassName1<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+modifier1 modifier2 class ClassName2<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(root.description(excl:  [.modifiers]), """
+attribute1
+attribute2
+class ClassName1<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+attribute1
+attribute2
+class ClassName2<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(root.description(excl:  [.attributes, .modifiers]), """
+class ClassName1<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+class ClassName2<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+    }
+    
+    func testClassDescription() {
+        let element = SwiftInterfaceClass(
+            attributes: ["attribute1", "attribute2"],
+            modifiers: ["modifier1", "modifier2"],
+            name: "ClassName",
+            genericParameterDescription: "<GenericParameterDescription>",
+            inheritance: ["Inheritance1", "Inheritance2"],
+            genericWhereClauseDescription: "GenericWhereClause",
+            children: []
+        )
+
+        XCTAssertEqual(element.description, """
+attribute1
+attribute2
+modifier1 modifier2 class ClassName<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(element.description(excl: [.attributes]), "modifier1 modifier2 class ClassName<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause")
+        XCTAssertEqual(element.description(excl: [.modifiers]), """
+attribute1
+attribute2
+class ClassName<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(element.description(excl: [.attributes, .modifiers]), "class ClassName<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause")
+        XCTAssertEqual(element.description(incl: [.modifiers]), "modifier1 modifier2 class ClassName<GenericParameterDescription>: Inheritance1, Inheritance2 GenericWhereClause")
+    }
+    
+    func testExtensionDescription() {
+        
+        let element = SwiftInterfaceExtension(
+            attributes: ["attribute1", "attribute2"],
+            modifiers: ["modifier1", "modifier2"],
+            extendedType: "ExtendedType",
+            inheritance: ["Inheritance1", "Inheritance2"],
+            genericWhereClauseDescription: "GenericWhereClause",
+            children: []
+        )
+        
+        XCTAssertEqual(element.description, """
+attribute1
+attribute2
+modifier1 modifier2 extension ExtendedType: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(element.description(excl: [.attributes]), "modifier1 modifier2 extension ExtendedType: Inheritance1, Inheritance2 GenericWhereClause")
+        XCTAssertEqual(element.description(excl: [.modifiers]), """
+attribute1
+attribute2
+extension ExtendedType: Inheritance1, Inheritance2 GenericWhereClause
+""")
+        XCTAssertEqual(element.description(excl: [.attributes, .modifiers]), "extension ExtendedType: Inheritance1, Inheritance2 GenericWhereClause")
+        XCTAssertEqual(element.description(incl: [.modifiers]), "modifier1 modifier2 extension ExtendedType: Inheritance1, Inheritance2 GenericWhereClause")
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes following scenario:
  - Protocols that get extended with default implementations that have an access level defined would show both in their public diff

### Example
```
public protocol ProtocolWithDefaultImplementation {
    func function() -> String
}

extension ProtocolWithDefaultImplementation {
    public func function() -> String {
        return ""
    }
}
```