### PR TITLE
Add Mint installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![🧪 Run Tests](https://github.com/Adyen/adyen-swift-public-api-diff/actions/workflows/run-tests.yml/badge.svg)](https://github.com/Adyen/adyen-swift-public-api-diff/actions/workflows/run-tests.yml)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAdyen%2Fadyen-swift-public-api-diff%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Adyen/adyen-swift-public-api-diff)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAdyen%2Fadyen-swift-public-api-diff%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Adyen/adyen-swift-public-api-diff)
+[![Mint](https://img.shields.io/badge/Mint-adyen%E2%80%93swift%E2%80%93public%E2%80%93api%E2%80%93diff-40c8a7?logo=leaf&logoColor=white)](Adyen/adyen-swift-public-api-diff#install-via-mint)
 
 ![github-header](https://github.com/user-attachments/assets/08ec7d60-eb0f-4937-b44a-afff02eff72c)
 
@@ -184,6 +185,11 @@ The public-api-diff can be used easily via the provided github action, which cre
     old: "5.12.0~https://github.com/Adyen/adyen-ios.git"
 ```
 See: [example workflow](https://github.com/Adyen/adyen-swift-public-api-diff/blob/main/Examples/github-workflow.yml)
+
+## Install via [Mint](https://github.com/yonaskolb/mint)
+```
+mint install Adyen/adyen-swift-public-api-diff
+```
 
 ## Alternatives
 - **swift-api-digester**


### PR DESCRIPTION
## Summary
Add Mint installation instructions to the README. Because it's as a public repo, it's already available and usable via Mint 🙌. I hope this makes it a little easier for those out there using the tool.

Mint is the go to package manager for Swift executables, it makes it straightforward to install & manage Swift CLI executables as binaries, usually handy on CI environments.

PS: I'm not sure about the badge, let me know in case it would be better off.