### PR TITLE
Fix extension matching

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
-        "version" : "1.5.1"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -42,15 +42,6 @@
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
         "revision" : "22a472ced4c621a0e41b982a6f32dec868d09392",
-        "version" : "0.59.1"
-      }
-    },
-    {
-      "identity" : "swiftlintplugins",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
-      "state" : {
-        "revision" : "8545ddf4de043e6f2051c5cf204f39ef778ebf6b",
         "version" : "0.59.1"
       }
     }

--- a/ReferencePackages/ReferencePackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/ReferencePackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -157,3 +157,31 @@ public extension CustomEnum {
 }
 
 public extension CustomEnum {}
+
+// MARK: - Integration Test Scenarios
+
+/// Tests extension matching fix: Multiple extensions with same description need child-based matching
+public enum TestExtensionMatching {
+    case initial
+}
+
+public extension TestExtensionMatching {
+    struct Data {
+        public let someValue: String
+    }
+}
+
+public extension TestExtensionMatching {
+    struct DataModel {
+        public var id: String
+        public init(id: String) {
+            self.id = id
+        }
+    }
+}
+
+public extension TestExtensionMatching {
+    struct Configuration {
+        public var timeout: Int
+    }
+}

--- a/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -242,3 +242,33 @@ public enum NewEnumAvailableInVersion17: String, Codable, Equatable {
     @available(macOS 15, *)
     public func laterAvailableFunction(){}
 }
+
+// MARK: - Integration Test Scenarios
+
+/// Tests extension matching fix: Multiple extensions with same description need child-based matching
+public enum TestExtensionMatching {
+    case initial
+}
+
+public extension TestExtensionMatching {
+    struct Data {
+        public var someValue: String
+    }
+}
+
+public extension TestExtensionMatching {
+    struct DataModel {
+        public var id: String
+        @available(*, deprecated, message: "Use default initializer")
+        public init(id: String) {
+            self.id = id
+        }
+    }
+}
+
+public extension TestExtensionMatching {
+    struct Configuration {
+        public var timeout: Int
+    }
+}
+

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceAnalyzer.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceAnalyzer.swift
@@ -68,7 +68,14 @@ struct SwiftInterfaceAnalyzer: SwiftInterfaceAnalyzing {
             }
 
             // First checking if we found a match based on the description
-            if let descriptionMatch = rhs.children.first(where: { $0.description == lhsElement.description }) {
+            // For extensions, we need special handling to find the best match based on child similarity
+            if lhsElement is SwiftInterfaceExtension {
+                let allDescriptionMatches = rhs.children.filter { $0.description == lhsElement.description }
+                if let bestMatch = findBestExtensionMatch(for: lhsElement, among: allDescriptionMatches) {
+                    return Self.recursiveCompare(element: lhsElement, to: bestMatch, oldFirst: oldFirst)
+                }
+                // No good match found, will fall through to isDiffable check or report as removal/addition
+            } else if let descriptionMatch = rhs.children.first(where: { $0.description == lhsElement.description }) {
                 // so we check if the children changed
                 return Self.recursiveCompare(element: lhsElement, to: descriptionMatch, oldFirst: oldFirst)
             }
@@ -113,5 +120,35 @@ struct SwiftInterfaceAnalyzer: SwiftInterfaceAnalyzing {
                 oldFirst: oldFirst
             )
         ]
+    }
+    
+    /// Finds the best matching extension from a list of candidates based on child similarity
+    /// Returns nil if no good match is found
+    private static func findBestExtensionMatch(
+        for lhsElement: any SwiftInterfaceElement,
+        among candidates: [any SwiftInterfaceElement]
+    ) -> (any SwiftInterfaceElement)? {
+        guard !candidates.isEmpty else { return nil }
+        
+        // If only one candidate, return it
+        if candidates.count == 1 {
+            return candidates.first
+        }
+        
+        // Calculate similarity score for each candidate based on matching children
+        let candidatesWithScores = candidates.map { candidate -> (element: any SwiftInterfaceElement, score: Int) in
+            let matchingChildren = lhsElement.children.filter { lhsChild in
+                candidate.children.contains { rhsChild in
+                    // Check if children match by diffableSignature
+                    rhsChild.diffableSignature == lhsChild.diffableSignature &&
+                    type(of: rhsChild) == type(of: lhsChild)
+                }
+            }
+            return (element: candidate, score: matchingChildren.count)
+        }
+        
+        // Return the candidate with the highest score
+        // If all scores are 0 (no matching children), return the first candidate as fallback
+        return candidatesWithScores.max(by: { $0.score < $1.score })?.element
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
@@ -57,8 +57,11 @@ struct SwiftInterfaceChangeConsolidator: SwiftInterfaceChangeConsolidating {
             let listOfChanges = listOfChanges(between: change, and: match)
 
             if listOfChanges.isEmpty {
-                print("⚠ We should not end up here - investigate how this happened")
-                break
+                // This happens when the element declaration is the same but recursiveDescription differs
+                // The elements themselves haven't changed, but their children have
+                // Don't consolidate them - this avoids false "modification" reports
+                // Continue processing remaining changes (don't break the loop)
+                continue
             }
 
             consolidatedChanges.append(

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceAnalyzer/SwiftInterfaceChangeConsolidator.swift
@@ -57,9 +57,7 @@ struct SwiftInterfaceChangeConsolidator: SwiftInterfaceChangeConsolidating {
             let listOfChanges = listOfChanges(between: change, and: match)
 
             if listOfChanges.isEmpty {
-                // This happens when the element declaration is the same but recursiveDescription differs
-                // The elements themselves haven't changed, but their children have
-                // Don't consolidate them - this avoids false "modification" reports
+                print("⚠ We should not end up here - investigate how this happened")
                 // Continue processing remaining changes (don't break the loop)
                 continue
             }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement+Declaration/SwiftInterfaceElement+Extension.swift
@@ -30,7 +30,10 @@ class SwiftInterfaceExtension: SwiftInterfaceElement {
 
     var parent: (any SwiftInterfaceElement)?
 
-    var diffableSignature: String { extendedType }
+    var diffableSignature: String {
+        // Include where clause to differentiate extensions with different constraints
+        [extendedType, genericWhereClauseDescription.map { "[\($0)]" }].compactMap { $0 }.joined()
+    }
 
     var consolidatableName: String { extendedType }
 

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -1,4 +1,5 @@
 # ⚠️ 59 public changes detected ⚠️
+_Comparing `new_private` to `old_private`_
 <table><tr><td>❇️</td><td><b>31 Additions</b></td></tr><tr><td>🔀</td><td><b>24 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -1,6 +1,5 @@
-# ⚠️ 57 public changes detected ⚠️
-_Comparing `new_private` to `old_private`_
-<table><tr><td>❇️</td><td><b>31 Additions</b></td></tr><tr><td>🔀</td><td><b>22 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
+# ⚠️ 59 public changes detected ⚠️
+<table><tr><td>❇️</td><td><b>31 Additions</b></td></tr><tr><td>🔀</td><td><b>24 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -494,6 +493,36 @@ public var getVar: T
 /**
 Changes:
 - Modified type from `ReferencePackage.OpenSpiConformingClass.CustomAssociatedType` to `T`
+*/
+```
+### `TestExtensionMatching.Data`
+#### 🔀 Modified
+```swift
+// From
+public let someValue: Swift.String { get }
+
+// To
+public var someValue: Swift.String
+
+/**
+Changes:
+- Modified from `let` to `var`
+- Removed accessors `get`
+*/
+```
+### `TestExtensionMatching.DataModel`
+#### 🔀 Modified
+```swift
+// From
+public init(id: Swift.String)
+
+// To
+@available(*, deprecated, message: "Use default initializer")
+public init(id: Swift.String)
+
+/**
+Changes:
+- Added attribute `@available(*, deprecated, message: "Use default initializer")`
 */
 ```
 

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -1,4 +1,5 @@
 # ⚠️ 50 public changes detected ⚠️
+Comparing `new_public` to `old_public`
 <table><tr><td>❇️</td><td><b>28 Additions</b></td></tr><tr><td>🔀</td><td><b>18 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -1,5 +1,5 @@
 # ⚠️ 50 public changes detected ⚠️
-Comparing `new_public` to `old_public`
+_Comparing `new_public` to `old_public`_
 <table><tr><td>❇️</td><td><b>28 Additions</b></td></tr><tr><td>🔀</td><td><b>18 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -1,6 +1,5 @@
-# ⚠️ 48 public changes detected ⚠️
-_Comparing `new_public` to `old_public`_
-<table><tr><td>❇️</td><td><b>28 Additions</b></td></tr><tr><td>🔀</td><td><b>16 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
+# ⚠️ 50 public changes detected ⚠️
+<table><tr><td>❇️</td><td><b>28 Additions</b></td></tr><tr><td>🔀</td><td><b>18 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -385,6 +384,36 @@ public var getVar: Swift.Int
 /**
 Changes:
 - Modified type from `any Swift.Equatable` to `Swift.Int`
+*/
+```
+### `TestExtensionMatching.Data`
+#### 🔀 Modified
+```swift
+// From
+public let someValue: Swift.String { get }
+
+// To
+public var someValue: Swift.String
+
+/**
+Changes:
+- Modified from `let` to `var`
+- Removed accessors `get`
+*/
+```
+### `TestExtensionMatching.DataModel`
+#### 🔀 Modified
+```swift
+// From
+public init(id: Swift.String)
+
+// To
+@available(*, deprecated, message: "Use default initializer")
+public init(id: Swift.String)
+
+/**
+Changes:
+- Added attribute `@available(*, deprecated, message: "Use default initializer")`
 */
 ```
 


### PR DESCRIPTION
* Improves extension matching logic in the analyzer:
    * No longer relies solely on description matching
    * Selects the best match based on similarity of child elements
* Updates diffable signature for extensions:
    * Now includes where clauses to better distinguish similar extensions
* Improves robustness of change consolidation:
    * Continues processing instead of stopping on empty change groups
* Adds integration test coverage:
    * Introduces test cases with multiple similar extensions
    * Validates correct matching and change detection


Addresses: https://github.com/Adyen/adyen-swift-public-api-diff/issues/150
