### PR TITLE
Correctly generating swiftmodule path

### DIFF
--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceFileLocator.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceFileLocator.swift
@@ -49,37 +49,32 @@ public struct SwiftInterfaceFileLocator {
 
         let swiftModulePathsForScheme = shell.execute("cd '\(derivedDataPath)'; find . -type d -name '\(schemeSwiftModuleName)'")
             .components(separatedBy: .newlines)
-            .map { URL(filePath: $0) }
+            .map { URL(filePath: derivedDataPath).appending(path: $0) }
 
         guard let swiftModulePath = swiftModulePathsForScheme.first?.path() else {
             throw FileHandlerError.pathDoesNotExist(path: "find . -type d -name '\(schemeSwiftModuleName)'")
         }
 
-        let completeSwiftModulePath = derivedDataPath + "/" + swiftModulePath
-
-        let swiftModuleContent = try fileHandler.contentsOfDirectory(atPath: completeSwiftModulePath)
+        let swiftModuleContent = try fileHandler.contentsOfDirectory(atPath: swiftModulePath)
 
         let swiftInterfacePaths: [String]
         switch type {
-        case .private:
-            swiftInterfacePaths = swiftModuleContent.filter { $0.hasSuffix(".private.swiftinterface") }
-        case .package:
-            swiftInterfacePaths = swiftModuleContent.filter { $0.hasSuffix(".package.swiftinterface") }
+        case .private, .package:
+            swiftInterfacePaths = swiftModuleContent.filter { $0.hasSuffix(".\(type.fileExtension)") }
         case .public:
-            swiftInterfacePaths = swiftModuleContent.filter { $0.hasSuffix(".swiftinterface") && !$0.hasSuffix(".private.swiftinterface") && !$0.hasSuffix(".package.swiftinterface") }
-        }
-
-        guard let swiftInterfacePath = swiftInterfacePaths.first else {
-            switch type {
-            case .private:
-                throw FileHandlerError.pathDoesNotExist(path: "'\(completeSwiftModulePath)/\(scheme).private.swiftinterface'")
-            case .package:
-                throw FileHandlerError.pathDoesNotExist(path: "'\(completeSwiftModulePath)/\(scheme).package.swiftinterface'")
-            case .public:
-                throw FileHandlerError.pathDoesNotExist(path: "'\(completeSwiftModulePath)/\(scheme).swiftinterface'")
+            swiftInterfacePaths = swiftModuleContent.filter {
+                $0.hasSuffix(".\(SwiftInterfaceType.public.fileExtension)") &&
+                !$0.hasSuffix(".\(SwiftInterfaceType.private.fileExtension)") &&
+                !$0.hasSuffix(".\(SwiftInterfaceType.package.fileExtension)")
             }
         }
 
-        return URL(filePath: "\(completeSwiftModulePath)/\(swiftInterfacePath)")
+        guard let swiftInterfacePath = swiftInterfacePaths.first else {
+            throw FileHandlerError.pathDoesNotExist(
+                path: "'\(swiftModulePath)/\(scheme).\(type.fileExtension)'"
+            )
+        }
+
+        return URL(filePath: swiftModulePath).appending(path: swiftInterfacePath)
     }
 }

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -19,4 +19,12 @@ public enum SwiftInterfaceType {
         case .package: "package"
         }
     }
+    
+    var fileExtension: String {
+        switch self {
+        case .private: "private.swiftinterface"
+        case .public: "swiftinterface"
+        case .package: "package.swiftinterface"
+        }
+    }
 }

--- a/Tests/UnitTests/SwiftInterfaceFileLocatorTests.swift
+++ b/Tests/UnitTests/SwiftInterfaceFileLocatorTests.swift
@@ -1,0 +1,236 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import FileHandlingModule
+@testable import PADSwiftInterfaceFileLocator
+import XCTest
+
+class SwiftInterfaceFileLocatorTests: XCTestCase {
+
+    func test_locate_public_swiftinterface() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+        let findResult = "./Build/Products/MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { command in
+            XCTAssertEqual(command, "cd '\(derivedDataPath)'; find . -type d -name '\(scheme).swiftmodule'")
+            return findResult
+        }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { path in
+            XCTAssertEqual(path, "/path/to/derived/data/./Build/Products/MyModule.swiftmodule")
+            return [
+                "arm64-apple-ios.swiftinterface",
+                "arm64-apple-ios.private.swiftinterface",
+                "x86_64-apple-ios-simulator.swiftinterface"
+            ]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public)
+        
+        XCTAssertEqual(
+            result.path(),
+            "/path/to/derived/data/./Build/Products/MyModule.swiftmodule/arm64-apple-ios.swiftinterface"
+        )
+    }
+
+    func test_locate_private_swiftinterface() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+        let findResult = "./Build/Products/MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { _ in
+            [
+                "arm64-apple-ios.swiftinterface",
+                "arm64-apple-ios.private.swiftinterface",
+                "x86_64-apple-ios-simulator.private.swiftinterface"
+            ]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .private)
+        
+        XCTAssertEqual(
+            result.path(),
+            "/path/to/derived/data/./Build/Products/MyModule.swiftmodule/arm64-apple-ios.private.swiftinterface"
+        )
+    }
+
+    func test_locate_package_swiftinterface() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+        let findResult = "./Build/Products/MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { _ in
+            [
+                "arm64-apple-ios.swiftinterface",
+                "arm64-apple-ios.package.swiftinterface",
+                "x86_64-apple-ios-simulator.package.swiftinterface"
+            ]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .package)
+        
+        XCTAssertEqual(
+            result.path(),
+            "/path/to/derived/data/./Build/Products/MyModule.swiftmodule/arm64-apple-ios.package.swiftinterface"
+        )
+    }
+
+    func test_locate_withTrailingSlashInDerivedDataPath() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data/"
+        let findResult = "./Build/Products/MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { path in
+            XCTAssertFalse(path.contains("//"), "Path should not contain double slashes: \(path)")
+            return ["arm64-apple-ios.swiftinterface"]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public)
+        
+        let resultPath = result.path()
+        XCTAssertFalse(resultPath.contains("//"), "Result path should not contain double slashes: \(resultPath)")
+    }
+
+    func test_locate_pathConstructionWithoutTrailingSlash() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/Users/test/DerivedData"
+        let findResult = "./MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { path in
+            XCTAssertEqual(path, "/Users/test/DerivedData/./MyModule.swiftmodule")
+            return ["arm64-apple-ios.swiftinterface"]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public)
+        
+        XCTAssertEqual(
+            result.path(),
+            "/Users/test/DerivedData/./MyModule.swiftmodule/arm64-apple-ios.swiftinterface"
+        )
+    }
+
+    func test_locate_public_excludesPrivateAndPackage() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+        let findResult = "./MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { _ in
+            [
+                "arm64-apple-ios.private.swiftinterface",
+                "arm64-apple-ios.package.swiftinterface",
+                "arm64-apple-ios.swiftinterface"
+            ]
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        let result = try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public)
+        
+        XCTAssertTrue(result.path().hasSuffix("arm64-apple-ios.swiftinterface"))
+        XCTAssertFalse(result.path().hasSuffix(".private.swiftinterface"))
+        XCTAssertFalse(result.path().hasSuffix(".package.swiftinterface"))
+    }
+
+    func test_locate_throwsWhenSwiftModuleNotFound() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in "" }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { _ in
+            throw FileHandlerError.pathDoesNotExist(path: "")
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        XCTAssertThrowsError(try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public))
+    }
+
+    func test_locate_throwsWhenSwiftInterfaceNotFound() throws {
+        let scheme = "MyModule"
+        let derivedDataPath = "/path/to/derived/data"
+        let findResult = "./MyModule.swiftmodule"
+
+        var mockShell = MockShell()
+        mockShell.handleExecute = { _ in findResult }
+
+        var mockFileHandler = MockFileHandler()
+        mockFileHandler.handleContentsOfDirectory = { _ in
+            []
+        }
+
+        let locator = SwiftInterfaceFileLocator(
+            fileHandler: mockFileHandler,
+            shell: mockShell,
+            logger: nil
+        )
+
+        XCTAssertThrowsError(try locator.locate(for: scheme, derivedDataPath: derivedDataPath, type: .public))
+    }
+}


### PR DESCRIPTION
Fixes an issue where the `.swiftmodule` directory could not be found due to incorrectly joining relative paths