### PR TITLE
Adding ownership tests

### DIFF
--- a/ReferencePackages/ReferencePackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/ReferencePackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -185,3 +185,50 @@ public extension TestExtensionMatching {
         public var timeout: Int
     }
 }
+
+// MARK: - Ownership Keywords Tests
+
+/// Tests for Swift ownership keywords (borrowing, consuming, inout, sending)
+public struct OwnershipTester {
+    public var value: String
+    
+    public init(value: String) {
+        self.value = value
+    }
+    
+    // Function with regular parameter (will add borrowing in new version)
+    public func regularFunction(_ param: String) {
+        _ = param
+    }
+    
+    // Function with inout parameter (will be removed in new version)
+    public func mutatingFunction(_ param: inout String) {
+        param = "modified"
+    }
+    
+    // Function with consuming parameter (will be removed in new version)
+    public func consumingFunction(_ param: consuming String) {
+        _ = param
+    }
+    
+    // Function without sending (will add sending in new version)
+    public func processingFunction(_ param: String) {
+        _ = param
+    }
+}
+
+// MARK: - Type Constraint Tests
+
+/// Tests for type constraints like ~Copyable and ~Escapable
+public struct TypeConstraintTester<T> {
+    public var value: T
+    
+    public init(value: T) {
+        self.value = value
+    }
+    
+    // Regular generic function (will add ~Copyable constraint and change signature in new version)
+    public func processValue<U>(_ value: U) {
+        _ = value
+    }
+}

--- a/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
+++ b/ReferencePackages/UpdatedPackage/Sources/ReferencePackage/ReferencePackage.swift
@@ -272,3 +272,67 @@ public extension TestExtensionMatching {
     }
 }
 
+// MARK: - Ownership Keywords Tests
+
+/// Tests for Swift ownership keywords (borrowing, consuming, inout, sending)
+public struct OwnershipTester {
+    public var value: String
+    
+    public init(value: String) {
+        self.value = value
+    }
+    
+    // Function with borrowing parameter (changed from regular)
+    public func regularFunction(_ param: borrowing String) {
+        _ = param
+    }
+    
+    // Function with regular parameter (changed from inout - removed inout)
+    public func mutatingFunction(_ param: String) {
+        _ = param
+    }
+    
+    // Function with regular parameter (changed from consuming - removed consuming)
+    public func consumingFunction(_ param: String) {
+        _ = param
+    }
+    
+    // New function with consuming parameter
+    public func newConsumingFunction(_ param: consuming String) {
+        _ = param
+    }
+    
+    // Function with sending parameter (changed from regular - added sending)
+    public func processingFunction(_ param: sending String) {
+        _ = param
+    }
+    
+    // New function with inout parameter (tests adding inout)
+    public func newMutatingFunction(_ param: inout String) {
+        param = "new"
+    }
+}
+
+// MARK: - Type Constraint Tests
+
+/// Tests for type constraints like ~Copyable and ~Escapable
+public struct TypeConstraintTester<T> {
+    public var value: T
+    
+    public init(value: T) {
+        self.value = value
+    }
+    
+    // Generic function with ~Copyable constraint (changed from regular)
+    // Note: ~Copyable types require ownership annotations
+    public func processValue<U>(_ value: consuming U) where U: ~Copyable {
+        _ = value
+    }
+    
+    // New function with ~Escapable constraint  
+    // Note: ~Escapable types cannot be returned, only used locally
+    public func processEscapable<U>(_ value: borrowing U) where U: ~Escapable {
+        _ = value
+    }
+}
+

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -1,6 +1,6 @@
-# ⚠️ 59 public changes detected ⚠️
+# ⚠️ 67 public changes detected ⚠️
 _Comparing `new_private` to `old_private`_
-<table><tr><td>❇️</td><td><b>31 Additions</b></td></tr><tr><td>🔀</td><td><b>24 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
+<table><tr><td>❇️</td><td><b>34 Additions</b></td></tr><tr><td>🔀</td><td><b>29 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -496,6 +496,63 @@ Changes:
 - Modified type from `ReferencePackage.OpenSpiConformingClass.CustomAssociatedType` to `T`
 */
 ```
+### `OwnershipTester`
+#### ❇️ Added
+```swift
+public func newConsumingFunction(_ param: consuming Swift.String) -> Swift.Void
+```
+```swift
+public func newMutatingFunction(_ param: inout Swift.String) -> Swift.Void
+```
+#### 🔀 Modified
+```swift
+// From
+public func consumingFunction(_ param: consuming Swift.String) -> Swift.Void
+
+// To
+public func consumingFunction(_ param: Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `consuming Swift.String` to `Swift.String`
+*/
+```
+```swift
+// From
+public func mutatingFunction(_ param: inout Swift.String) -> Swift.Void
+
+// To
+public func mutatingFunction(_ param: Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `inout Swift.String` to `Swift.String`
+*/
+```
+```swift
+// From
+public func processingFunction(_ param: Swift.String) -> Swift.Void
+
+// To
+public func processingFunction(_ param: sending Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `Swift.String` to `sending Swift.String`
+*/
+```
+```swift
+// From
+public func regularFunction(_ param: Swift.String) -> Swift.Void
+
+// To
+public func regularFunction(_ param: borrowing Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `Swift.String` to `borrowing Swift.String`
+*/
+```
 ### `TestExtensionMatching.Data`
 #### 🔀 Modified
 ```swift
@@ -524,6 +581,25 @@ public init(id: Swift.String)
 /**
 Changes:
 - Added attribute `@available(*, deprecated, message: "Use default initializer")`
+*/
+```
+### `TypeConstraintTester`
+#### ❇️ Added
+```swift
+public func processEscapable<U>(_ value: borrowing U) -> Swift.Void where U : ~Escapable
+```
+#### 🔀 Modified
+```swift
+// From
+public func processValue<U>(_ value: U) -> Swift.Void
+
+// To
+public func processValue<U>(_ value: consuming U) -> Swift.Void where U : ~Copyable
+
+/**
+Changes:
+- Added generic where clause `where U : ~Copyable`
+- Modified parameter `_`: Changed type from `U` to `consuming U`
 */
 ```
 

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -1,6 +1,6 @@
-# ⚠️ 50 public changes detected ⚠️
+# ⚠️ 58 public changes detected ⚠️
 _Comparing `new_public` to `old_public`_
-<table><tr><td>❇️</td><td><b>28 Additions</b></td></tr><tr><td>🔀</td><td><b>18 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
+<table><tr><td>❇️</td><td><b>31 Additions</b></td></tr><tr><td>🔀</td><td><b>23 Modifications</b></td></tr><tr><td>❌</td><td><b>4 Removals</b></td></tr></table>
 
 ---
 ## `ReferencePackage`
@@ -387,6 +387,63 @@ Changes:
 - Modified type from `any Swift.Equatable` to `Swift.Int`
 */
 ```
+### `OwnershipTester`
+#### ❇️ Added
+```swift
+public func newConsumingFunction(_ param: consuming Swift.String) -> Swift.Void
+```
+```swift
+public func newMutatingFunction(_ param: inout Swift.String) -> Swift.Void
+```
+#### 🔀 Modified
+```swift
+// From
+public func consumingFunction(_ param: consuming Swift.String) -> Swift.Void
+
+// To
+public func consumingFunction(_ param: Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `consuming Swift.String` to `Swift.String`
+*/
+```
+```swift
+// From
+public func mutatingFunction(_ param: inout Swift.String) -> Swift.Void
+
+// To
+public func mutatingFunction(_ param: Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `inout Swift.String` to `Swift.String`
+*/
+```
+```swift
+// From
+public func processingFunction(_ param: Swift.String) -> Swift.Void
+
+// To
+public func processingFunction(_ param: sending Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `Swift.String` to `sending Swift.String`
+*/
+```
+```swift
+// From
+public func regularFunction(_ param: Swift.String) -> Swift.Void
+
+// To
+public func regularFunction(_ param: borrowing Swift.String) -> Swift.Void
+
+/**
+Changes:
+- Modified parameter `_`: Changed type from `Swift.String` to `borrowing Swift.String`
+*/
+```
 ### `TestExtensionMatching.Data`
 #### 🔀 Modified
 ```swift
@@ -415,6 +472,25 @@ public init(id: Swift.String)
 /**
 Changes:
 - Added attribute `@available(*, deprecated, message: "Use default initializer")`
+*/
+```
+### `TypeConstraintTester`
+#### ❇️ Added
+```swift
+public func processEscapable<U>(_ value: borrowing U) -> Swift.Void where U : ~Escapable
+```
+#### 🔀 Modified
+```swift
+// From
+public func processValue<U>(_ value: U) -> Swift.Void
+
+// To
+public func processValue<U>(_ value: consuming U) -> Swift.Void where U : ~Copyable
+
+/**
+Changes:
+- Added generic where clause `where U : ~Copyable`
+- Modified parameter `_`: Changed type from `U` to `consuming U`
 */
 ```
 

--- a/Tests/UnitTests/OwnershipKeywordsTests.swift
+++ b/Tests/UnitTests/OwnershipKeywordsTests.swift
@@ -1,0 +1,456 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import PADSwiftInterfaceDiff
+import XCTest
+
+/// Tests for Swift ownership keywords, isolation keywords, and type constraints
+/// Covers: borrowing, consuming, inout, sending, isolated, ~Copyable, ~Escapable
+class OwnershipKeywordsTests: XCTestCase {
+    
+    func testBorrowingKeywordInFunctionParameter() {
+        let swiftCode = """
+        public func testFunc(_ param: borrowing String) -> String {
+            return param
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "testFunc")
+        XCTAssertEqual(function.parameters.count, 1)
+        XCTAssertEqual(function.parameters[0].type, "borrowing String")
+        XCTAssertEqual(function.parameters[0].firstName, "_")
+        
+        // Verify the parameter appears in the description
+        let description = function.description
+        XCTAssertTrue(description.contains("borrowing String"), "Description should contain 'borrowing String'")
+    }
+    
+    func testConsumingKeywordInFunctionParameter() {
+        let swiftCode = """
+        public func consume(_ param: consuming String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "consume")
+        XCTAssertEqual(function.parameters.count, 1)
+        XCTAssertEqual(function.parameters[0].type, "consuming String")
+        
+        // Verify the parameter appears in the description
+        let description = function.description
+        XCTAssertTrue(description.contains("consuming String"), "Description should contain 'consuming String'")
+    }
+    
+    func testInoutKeywordInFunctionParameter() {
+        let swiftCode = """
+        public func mutate(_ param: inout String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "mutate")
+        XCTAssertEqual(function.parameters.count, 1)
+        XCTAssertEqual(function.parameters[0].type, "inout String")
+        
+        // Verify the parameter appears in the description
+        let description = function.description
+        XCTAssertTrue(description.contains("inout String"), "Description should contain 'inout String'")
+    }
+    
+    func testOwnershipKeywordChangeDetection() {
+        let swiftCodeOld = """
+        public func testFunc(_ param: String) -> String {
+            return param
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc(_ param: borrowing String) -> String {
+            return param
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        // Test that differences are detected
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect parameter type change")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("borrowing") }),
+            "Difference should mention 'borrowing' keyword"
+        )
+    }
+    
+    func testConsumingKeywordRemovalDetection() {
+        let swiftCodeOld = """
+        public func testFunc(_ param: consuming String) -> String {
+            return param
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc(_ param: String) -> String {
+            return param
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        // Test that differences are detected
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect parameter type change")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("consuming") }),
+            "Difference should mention 'consuming' keyword"
+        )
+    }
+    
+    func testMultipleOwnershipKeywordsInFunction() {
+        let swiftCode = """
+        public func process(
+            _ borrowed: borrowing String,
+            _ consumed: consuming Int,
+            _ mutated: inout Double
+        ) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "process")
+        XCTAssertEqual(function.parameters.count, 3)
+        XCTAssertEqual(function.parameters[0].type, "borrowing String")
+        XCTAssertEqual(function.parameters[1].type, "consuming Int")
+        XCTAssertEqual(function.parameters[2].type, "inout Double")
+        
+        // Verify all ownership keywords appear in the description
+        let description = function.description
+        XCTAssertTrue(description.contains("borrowing String"))
+        XCTAssertTrue(description.contains("consuming Int"))
+        XCTAssertTrue(description.contains("inout Double"))
+    }
+    
+    // MARK: - Inout Add/Remove Tests
+    
+    func testInoutKeywordAddition() {
+        let swiftCodeOld = """
+        public func testFunc(_ param: String) -> Void {
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc(_ param: inout String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect parameter type change")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("inout") }),
+            "Difference should mention 'inout' keyword"
+        )
+    }
+    
+    func testInoutKeywordRemoval() {
+        let swiftCodeOld = """
+        public func testFunc(_ param: inout String) -> Void {
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc(_ param: String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect parameter type change")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("inout") }),
+            "Difference should mention 'inout' keyword"
+        )
+    }
+    
+    // MARK: - Sending Keyword Tests
+    
+    func testSendingKeywordInFunctionParameter() {
+        let swiftCode = """
+        public func testFunc(_ param: sending String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "testFunc")
+        XCTAssertEqual(function.parameters.count, 1)
+        XCTAssertEqual(function.parameters[0].type, "sending String")
+        
+        let description = function.description
+        XCTAssertTrue(description.contains("sending String"), "Description should contain 'sending String'")
+    }
+    
+    func testSendingKeywordAddition() {
+        let swiftCodeOld = """
+        public func testFunc(_ param: String) -> Void {
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc(_ param: sending String) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect parameter type change")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("sending") }),
+            "Difference should mention 'sending' keyword"
+        )
+    }
+    
+    // MARK: - Isolated Keyword Tests
+    
+    func testIsolatedKeywordInFunctionParameter() {
+        let swiftCode = """
+        public func testFunc(_ actor: isolated MyActor) -> Void {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "testFunc")
+        XCTAssertEqual(function.parameters.count, 1)
+        XCTAssertEqual(function.parameters[0].type, "isolated MyActor")
+        
+        let description = function.description
+        XCTAssertTrue(description.contains("isolated MyActor"), "Description should contain 'isolated MyActor'")
+    }
+    
+    // MARK: - Type Constraint Tests (~Copyable, ~Escapable)
+    
+    func testNonCopyableTypeConstraint() {
+        let swiftCode = """
+        public func testFunc<T>(_ value: T) -> T where T: ~Copyable {
+            return value
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "testFunc")
+        XCTAssertNotNil(function.genericWhereClauseDescription)
+        XCTAssertTrue(
+            function.genericWhereClauseDescription?.contains("~Copyable") ?? false,
+            "Should contain ~Copyable constraint"
+        )
+        
+        let description = function.description
+        XCTAssertTrue(description.contains("~Copyable"), "Description should contain '~Copyable'")
+    }
+    
+    func testNonEscapableTypeConstraint() {
+        let swiftCode = """
+        public func testFunc<T>(_ value: T) -> T where T: ~Escapable {
+            return value
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "testFunc")
+        XCTAssertNotNil(function.genericWhereClauseDescription)
+        XCTAssertTrue(
+            function.genericWhereClauseDescription?.contains("~Escapable") ?? false,
+            "Should contain ~Escapable constraint"
+        )
+        
+        let description = function.description
+        XCTAssertTrue(description.contains("~Escapable"), "Description should contain '~Escapable'")
+    }
+    
+    func testNonCopyableConstraintAddition() {
+        let swiftCodeOld = """
+        public func testFunc<T>(_ value: T) -> T {
+            return value
+        }
+        """
+        
+        let swiftCodeNew = """
+        public func testFunc<T>(_ value: T) -> T where T: ~Copyable {
+            return value
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let oldRoot = parser.parse(source: swiftCodeOld, moduleName: "TestModule")
+        let newRoot = parser.parse(source: swiftCodeNew, moduleName: "TestModule")
+        
+        guard let oldFunction = oldRoot.children.first as? SwiftInterfaceFunction,
+              let newFunction = newRoot.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected function elements")
+            return
+        }
+        
+        let differences = newFunction.differences(to: oldFunction)
+        
+        XCTAssertFalse(differences.isEmpty, "Should detect where clause addition")
+        XCTAssertTrue(
+            differences.contains(where: { $0.contains("~Copyable") }),
+            "Difference should mention '~Copyable' constraint"
+        )
+    }
+    
+    // MARK: - Combined Tests
+    
+    func testAllParameterModifiersTogether() {
+        let swiftCode = """
+        public func complexFunc<T, U>(
+            _ borrowed: borrowing String,
+            _ consumed: consuming Int,
+            _ mutated: inout Double,
+            _ sent: sending T,
+            _ actor: isolated MyActor
+        ) -> U where T: ~Copyable, U: ~Escapable {
+        }
+        """
+        
+        let parser = SwiftInterfaceParser()
+        let root = parser.parse(source: swiftCode, moduleName: "TestModule")
+        
+        guard let function = root.children.first as? SwiftInterfaceFunction else {
+            XCTFail("Expected a function element")
+            return
+        }
+        
+        XCTAssertEqual(function.name, "complexFunc")
+        XCTAssertEqual(function.parameters.count, 5)
+        
+        // Verify all parameter types
+        XCTAssertEqual(function.parameters[0].type, "borrowing String")
+        XCTAssertEqual(function.parameters[1].type, "consuming Int")
+        XCTAssertEqual(function.parameters[2].type, "inout Double")
+        XCTAssertEqual(function.parameters[3].type, "sending T")
+        XCTAssertEqual(function.parameters[4].type, "isolated MyActor")
+        
+        // Verify where clause
+        XCTAssertNotNil(function.genericWhereClauseDescription)
+        let whereClause = function.genericWhereClauseDescription ?? ""
+        XCTAssertTrue(whereClause.contains("~Copyable"))
+        XCTAssertTrue(whereClause.contains("~Escapable"))
+        
+        // Verify description contains all keywords
+        let description = function.description
+        XCTAssertTrue(description.contains("borrowing String"))
+        XCTAssertTrue(description.contains("consuming Int"))
+        XCTAssertTrue(description.contains("inout Double"))
+        XCTAssertTrue(description.contains("sending T"))
+        XCTAssertTrue(description.contains("isolated MyActor"))
+        XCTAssertTrue(description.contains("~Copyable"))
+        XCTAssertTrue(description.contains("~Escapable"))
+    }
+}


### PR DESCRIPTION
Adding tests for:
- sending
- borrowing
- consuming
- nonisolated(nonsending)
- ~Copyable
- ~Escapable
- ...

See: https://github.com/Adyen/adyen-swift-public-api-diff/issues/161