### PR TITLE
Handling outdated branch source branches

### DIFF
--- a/Sources/ExecutableTargets/CommandLineTool/ProjectToOutputCommand.swift
+++ b/Sources/ExecutableTargets/CommandLineTool/ProjectToOutputCommand.swift
@@ -82,6 +82,8 @@ struct ProjectToOutputCommand: AsyncParsableCommand {
                 logger: logger
             )
 
+            warnings += projectBuilderResult.warnings
+
             // MARK: - Analyzing .swiftinterface files
 
             let swiftInterfaceChanges = try await Self.analyzeSwiftInterfaceFiles(

--- a/Sources/PublicModules/PADProjectBuilder/ProjectBuilder.swift
+++ b/Sources/PublicModules/PADProjectBuilder/ProjectBuilder.swift
@@ -30,6 +30,8 @@ public struct ProjectBuilder {
         public let swiftInterfaceFiles: [SwiftInterfaceFile]
         /// The project directories for the setup projects
         public let projectDirectories: (old: URL, new: URL)
+        /// Warnings produced during project setup (e.g. merge conflicts)
+        public let warnings: [String]
     }
 
     private let projectType: ProjectType
@@ -93,7 +95,7 @@ public struct ProjectBuilder {
             logger: logger
         )
 
-        let projectDirectories = try await projectSetupHelper.setupProjects(
+        let setupResult = try await projectSetupHelper.setupProjects(
             oldSource: oldSource,
             newSource: newSource,
             projectType: projectType
@@ -112,13 +114,14 @@ public struct ProjectBuilder {
         )
 
         let swiftInterfaceFiles = try await producer.produceInterfaceFiles(
-            oldProjectDirectory: projectDirectories.old,
-            newProjectDirectory: projectDirectories.new
+            oldProjectDirectory: setupResult.oldDirectory,
+            newProjectDirectory: setupResult.newDirectory
         )
 
         return .init(
             swiftInterfaceFiles: swiftInterfaceFiles,
-            projectDirectories: projectDirectories
+            projectDirectories: (old: setupResult.oldDirectory, new: setupResult.newDirectory),
+            warnings: setupResult.warnings
         )
     }
 }

--- a/Sources/PublicModules/PADProjectBuilder/ProjectSetup/Git.swift
+++ b/Sources/PublicModules/PADProjectBuilder/ProjectSetup/Git.swift
@@ -14,11 +14,14 @@ import ShellModule
 
 internal enum GitError: LocalizedError, Equatable {
     case couldNotClone(branchOrTag: String, repository: String)
+    case mergeConflict(branch: String)
 
     var errorDescription: String? {
         switch self {
         case let .couldNotClone(branchOrTag, repository):
             "Could not clone \(repository) @ \(branchOrTag) - Please check the debug logs for more information"
+        case let .mergeConflict(branch):
+            "The compared branches have conflicting changes. This comparison may be inaccurate — please update your branch with the latest changes from `\(branch)` and re-run."
         }
     }
 }
@@ -37,6 +40,33 @@ internal struct Git {
         self.shell = shell
         self.fileHandler = fileHandler
         self.logger = logger
+    }
+
+    /// Merges a branch from a repository into an already-cloned directory.
+    ///
+    /// This is used to avoid misleading diff output when the source branch is out of date
+    /// with the target branch: by merging the target into the source first, the diff only
+    /// reflects the source branch's actual changes.
+    ///
+    /// - Parameters:
+    ///   - branch: The branch to merge
+    ///   - repository: The repository the branch lives in
+    ///   - clonedDirectoryPath: The local directory of the already-cloned source
+    ///
+    /// - Throws: ``GitError/mergeConflict(branch:)`` if the merge produces conflicts
+    func merge(_ branch: String, from repository: String, into clonedDirectoryPath: String) throws {
+        logger?.log("🔀 Merging \(repository) @ \(branch) into \(clonedDirectoryPath)", from: String(describing: Self.self))
+
+        let fetchOutput = shell.execute("git -C '\(clonedDirectoryPath)' fetch origin \(branch)")
+        logger?.debug(fetchOutput, from: String(describing: Self.self))
+
+        let mergeOutput = shell.execute("git -C '\(clonedDirectoryPath)' merge origin/\(branch) --no-edit")
+        logger?.debug(mergeOutput, from: String(describing: Self.self))
+
+        if fileHandler.fileExists(atPath: "\(clonedDirectoryPath)/.git/MERGE_HEAD") {
+            shell.execute("git -C '\(clonedDirectoryPath)' merge --abort")
+            throw GitError.mergeConflict(branch: branch)
+        }
     }
 
     /// Clones a repository at a specific branch or tag into the current directory

--- a/Sources/PublicModules/PADProjectBuilder/ProjectSetup/ProjectSetupHelper.swift
+++ b/Sources/PublicModules/PADProjectBuilder/ProjectSetup/ProjectSetupHelper.swift
@@ -72,7 +72,7 @@ extension ProjectSetupHelper {
         oldSource: ProjectSource,
         newSource: ProjectSource,
         projectType: ProjectType
-    ) async throws -> (old: URL, new: URL) {
+    ) async throws -> (oldDirectory: URL, newDirectory: URL, warnings: [String]) {
         let projectSetupHelper = ProjectSetupHelper(
             workingDirectoryPath: workingDirectoryPath,
             shell: Shell(logger: logger),
@@ -83,7 +83,24 @@ extension ProjectSetupHelper {
         async let newProjectDirectoryPath = try projectSetupHelper.setup(newSource, projectType: projectType)
         async let oldProjectDirectoryPath = try projectSetupHelper.setup(oldSource, projectType: projectType)
 
-        return try await (oldProjectDirectoryPath, newProjectDirectoryPath)
+        let directories = try await (old: oldProjectDirectoryPath, new: newProjectDirectoryPath)
+
+        // Merge the old branch into the new clone so the diff only reflects the source
+        // branch's actual changes, avoiding misleading inverse diffs when the source is
+        // out of date with the target.
+        var warnings = [String]()
+        if case let .git(oldBranch, oldRepository) = oldSource,
+           case let .git(_, newRepository) = newSource,
+           oldRepository == newRepository {
+            let git = Git(shell: shell, fileHandler: fileHandler, logger: logger)
+            do {
+                try git.merge(oldBranch, from: oldRepository, into: directories.new.path)
+            } catch let error as GitError {
+                warnings.append(error.localizedDescription)
+            }
+        }
+
+        return (oldDirectory: directories.old, newDirectory: directories.new, warnings: warnings)
     }
 }
 

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -28,3 +28,5 @@ public enum SwiftInterfaceType {
         }
     }
 }
+
+public enum SomeChangeToTestMergingBehavior {}

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -28,3 +28,5 @@ public enum SwiftInterfaceType {
         }
     }
 }
+
+public enum ChangeToTestMergingBehavior {}

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -28,5 +28,3 @@ public enum SwiftInterfaceType {
         }
     }
 }
-
-public enum SomeChangeToTestMergingBehavior {}

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -28,4 +28,3 @@ public enum SwiftInterfaceType {
         }
     }
 }
-

--- a/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
+++ b/Sources/Shared/Public/PADSwiftInterfaceFileLocator/SwiftInterfaceType.swift
@@ -28,3 +28,4 @@ public enum SwiftInterfaceType {
         }
     }
 }
+

--- a/Tests/UnitTests/GitTests.swift
+++ b/Tests/UnitTests/GitTests.swift
@@ -9,7 +9,52 @@ import Testing
 
 @Suite
 struct GitTests {
-    
+
+    @Test func mergeSuccess() throws {
+
+        let branch = "branch"
+        let repository = "repository"
+        let clonedDirectoryPath = "clonedDirectoryPath"
+        let fetchOutput = "fetch-output"
+        let mergeOutput = "merge-output"
+
+        let (shell, logger, fileHandler) = setupMerge(
+            branch: branch,
+            repository: repository,
+            clonedDirectoryPath: clonedDirectoryPath,
+            fetchOutput: fetchOutput,
+            mergeOutput: mergeOutput,
+            mergeHeadExists: false
+        )
+
+        let git = Git(shell: shell, fileHandler: fileHandler, logger: logger)
+        try git.merge(branch, from: repository, into: clonedDirectoryPath)
+    }
+
+    @Test func mergeFail() throws {
+
+        let branch = "branch"
+        let repository = "repository"
+        let clonedDirectoryPath = "clonedDirectoryPath"
+
+        let (shell, logger, fileHandler) = setupMerge(
+            branch: branch,
+            repository: repository,
+            clonedDirectoryPath: clonedDirectoryPath,
+            fetchOutput: "",
+            mergeOutput: "",
+            mergeHeadExists: true
+        )
+
+        let git = Git(shell: shell, fileHandler: fileHandler, logger: logger)
+
+        let expectedError = GitError.mergeConflict(branch: branch)
+        #expect(throws: expectedError) {
+            try git.merge(branch, from: repository, into: clonedDirectoryPath)
+        }
+        #expect(expectedError.localizedDescription == "The compared branches have conflicting changes. This comparison may be inaccurate — please update your branch with the latest changes from `\(branch)` and re-run.")
+    }
+
     @Test func cloneSuccess() throws {
         
         let repository = "repository"
@@ -78,7 +123,63 @@ struct GitTests {
 }
 
 private extension GitTests {
-    
+
+    func setupMerge(
+        branch: String,
+        repository: String,
+        clonedDirectoryPath: String,
+        fetchOutput: String,
+        mergeOutput: String,
+        mergeHeadExists: Bool
+    ) -> (MockShell, MockLogger, MockFileHandler) {
+
+        var callCount = 0
+        var expectedCommands = [
+            "git -C '\(clonedDirectoryPath)' fetch origin \(branch)",
+            "git -C '\(clonedDirectoryPath)' merge origin/\(branch) --no-edit"
+        ]
+        var expectedOutputs = [fetchOutput, mergeOutput]
+        if mergeHeadExists {
+            expectedCommands.append("git -C '\(clonedDirectoryPath)' merge --abort")
+            expectedOutputs.append("")
+        }
+
+        let shell = MockShell { command in
+            let index = callCount
+            callCount += 1
+            if index < expectedCommands.count {
+                #expect(command == expectedCommands[index])
+                return expectedOutputs[index]
+            }
+            return ""
+        }
+
+        var fileHandler = MockFileHandler()
+        fileHandler.handleFileExists = { path in
+            #expect(path == "\(clonedDirectoryPath)/.git/MERGE_HEAD")
+            return mergeHeadExists
+        }
+
+        var debugCallCount = 0
+        let expectedDebugOutputs = [fetchOutput, mergeOutput]
+
+        var logger = MockLogger()
+        logger.handleLog = { message, subsystem in
+            #expect(message == "🔀 Merging \(repository) @ \(branch) into \(clonedDirectoryPath)")
+            #expect(subsystem == "Git")
+        }
+        logger.handleDebug = { message, subsystem in
+            let index = debugCallCount
+            debugCallCount += 1
+            if index < expectedDebugOutputs.count {
+                #expect(message == expectedDebugOutputs[index])
+            }
+            #expect(subsystem == "Git")
+        }
+
+        return (shell, logger, fileHandler)
+    }
+
     func setupShell(
         branch: String,
         repository: String,


### PR DESCRIPTION
Fix misleading diff output when source branch is out of date with target

When the source branch (--new) has not been updated with recent changes from the target branch (--old), the tool produced incorrect output — changes made on the target branch appeared inversely as modifications on the source branch.

**Root cause:** The tool cloned each branch independently and performed a straight two-way diff, with no awareness of their divergence point.

**Fix:** Before building the source branch, the target branch is merged into the source clone (when both are from the same git repository). This ensures the diff only reflects the source branch's actual changes. If the merge produces conflicts, the build proceeds with the original source but surfaces a warning in the output:

> [!WARNING] 
> The compared branches have conflicting changes. This comparison may be inaccurate — please update your branch with the latest changes from `\(branch)` and re-run.

Fixes: https://github.com/Adyen/adyen-swift-public-api-diff/issues/168