### PR TITLE
Improving speed and readability

### DIFF
--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement+DiffHelper+Parameter.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement+DiffHelper+Parameter.swift
@@ -58,7 +58,7 @@ extension SwiftInterfaceElement {
             
             let modificationDiffPrefix = modificationDiffDescriptionPrefix(
                 propertyType: propertyType,
-                firstName: oldParameter.firstName,
+                firstName: oldParameter.displayName,
                 index: index
             )
             

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElement.swift
@@ -135,6 +135,24 @@ extension SwiftInterfaceElement {
     }
 }
 
+/// A key uniquely identifying a memoized recursive description
+private struct RecursiveDescriptionCacheKey: Hashable {
+    let id: ObjectIdentifier
+    let tokens: Set<SwiftInterfaceElementDescriptionToken>
+}
+
+/// A process-wide memoization cache for `recursiveDescription`.
+///
+/// The diffing algorithm requests the recursive description of the same elements many times.
+/// Recomputing it (which rebuilds and re-sorts the entire subtree on every call) makes diffing
+/// large modules (e.g. `SwiftUI`, `Foundation`) effectively hang. Elements are reference types
+/// that are not mutated during analysis, so their description can safely be cached by identity.
+///
+/// - Note: Access is not synchronized. Analysis runs on a single thread.
+private enum RecursiveDescriptionCache {
+    static var storage: [RecursiveDescriptionCacheKey: String] = [:]
+}
+
 extension SwiftInterfaceElement {
 
     /// Produces the complete recursive description of the element
@@ -142,24 +160,48 @@ extension SwiftInterfaceElement {
         indentation: Int = 0,
         incl tokens: Set<SwiftInterfaceElementDescriptionToken> = Set(SwiftInterfaceElementDescriptionToken.allCases)
     ) -> String {
-        let spacer = "  "
-        var recursiveDescription = "\(indentedDescription(indentation: indentation, incl: tokens))"
+        let canonicalDescription = canonicalRecursiveDescription(incl: tokens)
+        guard indentation > 0 else { return canonicalDescription }
+        return canonicalDescription.indented(by: indentation)
+    }
+
+    /// The recursive description at indentation `0`, memoized per element + token set.
+    ///
+    /// Any indented variant is derived from this by prefixing each line, since
+    /// `recursiveDescription(indentation: n)` is exactly this value with every line prefixed
+    /// by `n` levels of indentation.
+    private func canonicalRecursiveDescription(
+        incl tokens: Set<SwiftInterfaceElementDescriptionToken>
+    ) -> String {
+        let cacheKey = RecursiveDescriptionCacheKey(id: ObjectIdentifier(self), tokens: tokens)
+        if let cached = RecursiveDescriptionCache.storage[cacheKey] { return cached }
+
+        var recursiveDescription = description(incl: tokens)
         if !self.children.isEmpty {
             recursiveDescription.append(" {")
             for child in self.children.sorted(by: { $0.description(incl: tokens) < $1.description(incl: tokens) }) {
-                recursiveDescription.append("\n\(child.recursiveDescription(indentation: indentation + 1, incl: tokens))")
+                recursiveDescription.append("\n\(child.canonicalRecursiveDescription(incl: tokens).indented(by: 1))")
             }
-            recursiveDescription.append("\n\(String(repeating: spacer, count: indentation))}")
+            recursiveDescription.append("\n}")
         }
 
+        RecursiveDescriptionCache.storage[cacheKey] = recursiveDescription
         return recursiveDescription
     }
     
     func indentedDescription(indentation: Int, incl tokens: Set<SwiftInterfaceElementDescriptionToken>) -> String {
-        var components = description(incl: tokens).components(separatedBy: .newlines)
-        for (index, component) in components.enumerated() {
-            components[index] = "\(String(repeating: "  ", count: indentation))\(component)"
-        }
-        return components.joined(separator: "\n")
+        description(incl: tokens).indented(by: indentation)
+    }
+}
+
+private extension String {
+
+    /// Prefixes every line with `indentation` levels (2 spaces each) of indentation
+    func indented(by indentation: Int) -> String {
+        guard indentation > 0 else { return self }
+        let prefix = String(repeating: "  ", count: indentation)
+        return components(separatedBy: .newlines)
+            .map { "\(prefix)\($0)" }
+            .joined(separator: "\n")
     }
 }

--- a/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElementParameter.swift
+++ b/Sources/PublicModules/PADSwiftInterfaceDiff/SwiftInterfaceParser/SwiftInterfaceElement/SwiftInterfaceElementParameter.swift
@@ -47,4 +47,13 @@ extension SwiftInterfaceElementParameter {
     var valueForDiffableSignature: String {
         "\(firstName ?? "_"):"
     }
+    
+    /// A human-readable name for the parameter used in change descriptions.
+    ///
+    /// Prefers the external argument label, but falls back to the internal name
+    /// when the label is omitted (`_`), e.g. `_ action: ...` is reported as `action`.
+    var displayName: String? {
+        if let firstName, firstName != "_" { return firstName }
+        return secondName ?? firstName
+    }
 }

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-private.md
@@ -514,7 +514,7 @@ public func consumingFunction(_ param: Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `consuming Swift.String` to `Swift.String`
+- Modified parameter `param`: Changed type from `consuming Swift.String` to `Swift.String`
 */
 ```
 ```swift
@@ -526,7 +526,7 @@ public func mutatingFunction(_ param: Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `inout Swift.String` to `Swift.String`
+- Modified parameter `param`: Changed type from `inout Swift.String` to `Swift.String`
 */
 ```
 ```swift
@@ -538,7 +538,7 @@ public func processingFunction(_ param: sending Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `Swift.String` to `sending Swift.String`
+- Modified parameter `param`: Changed type from `Swift.String` to `sending Swift.String`
 */
 ```
 ```swift
@@ -550,7 +550,7 @@ public func regularFunction(_ param: borrowing Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `Swift.String` to `borrowing Swift.String`
+- Modified parameter `param`: Changed type from `Swift.String` to `borrowing Swift.String`
 */
 ```
 ### `TestExtensionMatching.Data`
@@ -599,7 +599,7 @@ public func processValue<U>(_ value: consuming U) -> Swift.Void where U : ~Copya
 /**
 Changes:
 - Added generic where clause `where U : ~Copyable`
-- Modified parameter `_`: Changed type from `U` to `consuming U`
+- Modified parameter `value`: Changed type from `U` to `consuming U`
 */
 ```
 

--- a/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
+++ b/Tests/IntegrationTests/Resources/expected-reference-changes-swift-interface-public.md
@@ -405,7 +405,7 @@ public func consumingFunction(_ param: Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `consuming Swift.String` to `Swift.String`
+- Modified parameter `param`: Changed type from `consuming Swift.String` to `Swift.String`
 */
 ```
 ```swift
@@ -417,7 +417,7 @@ public func mutatingFunction(_ param: Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `inout Swift.String` to `Swift.String`
+- Modified parameter `param`: Changed type from `inout Swift.String` to `Swift.String`
 */
 ```
 ```swift
@@ -429,7 +429,7 @@ public func processingFunction(_ param: sending Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `Swift.String` to `sending Swift.String`
+- Modified parameter `param`: Changed type from `Swift.String` to `sending Swift.String`
 */
 ```
 ```swift
@@ -441,7 +441,7 @@ public func regularFunction(_ param: borrowing Swift.String) -> Swift.Void
 
 /**
 Changes:
-- Modified parameter `_`: Changed type from `Swift.String` to `borrowing Swift.String`
+- Modified parameter `param`: Changed type from `Swift.String` to `borrowing Swift.String`
 */
 ```
 ### `TestExtensionMatching.Data`
@@ -490,7 +490,7 @@ public func processValue<U>(_ value: consuming U) -> Swift.Void where U : ~Copya
 /**
 Changes:
 - Added generic where clause `where U : ~Copyable`
-- Modified parameter `_`: Changed type from `U` to `consuming U`
+- Modified parameter `value`: Changed type from `U` to `consuming U`
 */
 ```
 


### PR DESCRIPTION
## Summary

1. **Performance** — Make diffing large modules (e.g. `SwiftUI`, `Foundation`) actually complete instead of hanging.
2. **Readability** — Report the meaningful parameter name in change descriptions instead of `_`.

## Motivation

- When diffing a large framework the process maxed out the CPU core indefinitely.
- For parameters with an omitted external label (e.g. `_ action: T`), change messages read `` Modified parameter `_` ``, which is uninformative when a declaration has several such parameters.

## Changes

### 1. Memoize `recursiveDescription` (performance)

`recursiveDescription()` rebuilt and **re-sorted the entire subtree on every call**, and the diff algorithm invokes it many times per node (including inside sibling loops). This made comparison super-quadratic.

Elements are reference types that aren't mutated during analysis, so identity-based caching is safe. Access is unsynchronized because analysis runs single-threaded (documented inline).

**Result:** SwiftUI (iOS 26.2 → 26.4) now diffs in **~2.7s**.

### 2. Use internal parameter name in change descriptions (readability)

- Added `SwiftInterfaceElementParameter.displayName`, which prefers the external label but falls back to the internal name when the label is `_`.
- Used it when composing parameter modification messages.

**Before:** `` Modified parameter `_`: Changed type from ... ``
**After:** `` Modified parameter `action`: Changed type from ... ``